### PR TITLE
Fix broken Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,10 @@ python:
   - '2.7'
   - '3.5'
 
-virtualenv:
-  system_site_packages: true
-
 before_install:
-  - sudo apt-get install -qq python-numpy python-scipy python-matplotlib
+  - sudo apt-get build-dep python-scipy
   - pip install coveralls
+  - pip install scipy
 
 install: pip install -r requirements.txt
 


### PR DESCRIPTION
Use of `system_site_packages: true` has been deprecated. This builds scipy in the virtualenv.