### PR TITLE
Adds MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include DESCRIPTION.txt
+include requirements.txt
+include LICENSE


### PR DESCRIPTION
Tried to pip install the package but it failed due to a missing DESCRIPTION.txt file. Added a MANIFEST.in file with includes for DESCRIPTION.txt. Also added includes in the MANIFEST.in file for requirements.txt and LICENSE to conform to generally accepted practices for MANIFEST.in files. 