### PR TITLE
Fixed matplotlib test failures.

### DIFF
--- a/tests/test_bestfit.py
+++ b/tests/test_bestfit.py
@@ -19,6 +19,9 @@ Tests for the bestfit module.
 
 import unittest
 import numpy as np
+import matplotlib
+# set to use a non-interactive backend
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
 from yellowbrick.bestfit import *

--- a/tests/test_yb_rcmod.py
+++ b/tests/test_yb_rcmod.py
@@ -23,6 +23,11 @@ from yellowbrick import yb_rcmod
 
 class RCParamTester(unittest.TestCase):
 
+    excluded_params = {
+        "backend",  # This cannot be changed by manipulating rc
+        "svg.embed_char_paths"  # This param causes test issues and is deprecated anyway
+    }
+
     def flatten_list(self, orig_list):
 
         iter_list = map(np.atleast_1d, orig_list)
@@ -32,8 +37,7 @@ class RCParamTester(unittest.TestCase):
     def assert_rc_params(self, params):
 
         for k, v in params.items():
-            if k == "svg.embed_char_paths":
-                # This param causes test issues and is deprecated anyway
+            if k in self.excluded_params:
                 continue
             elif isinstance(v, np.ndarray):
                 npt.assert_array_equal(mpl.rcParams[k], v)


### PR DESCRIPTION
The test failures are caused by not running in an interactive
environment. Using the "Agg" backend should solve this issue.