### PR TITLE
Fixes to the resolve colors function

### DIFF
--- a/tests/test_style/test_colors.py
+++ b/tests/test_style/test_colors.py
@@ -10,15 +10,19 @@
 # ID: test_colors.py [c6aff34] benjamin@bengfort.com $
 
 """
-Tests for the color utilities and helpers module
+Tests for the color utilities and helper functions
 """
 
 ##########################################################################
 ## Imports
 ##########################################################################
 
-from yellowbrick.style import *
+import pytest
+
+from matplotlib import cm
 from yellowbrick.style.colors import *
+from yellowbrick.style.palettes import ColorPalette, PALETTES
+
 from tests.base import VisualTestCase
 
 
@@ -26,15 +30,163 @@ from tests.base import VisualTestCase
 ## Color Tests
 ##########################################################################
 
-class ColorUtilitiesTests(VisualTestCase):
+def test_get_color_cycle():
+    """
+    Test the retreival of the current color cycle
+    """
+    c = get_color_cycle()
+    assert len(c) == 6
 
-    def test_get_color_cycle(self):
-        """
-        Test the retreival of the current color cycle
-        """
+    with ColorPalette('paired'):
         c = get_color_cycle()
-        self.assertEqual(len(c), 6)
+        assert len(c) == 12
 
-        set_palette('paired')
-        c = get_color_cycle()
-        self.assertEqual(len(c), 12)
+    c = get_color_cycle()
+    assert len(c) == 6
+
+
+class TestResolveColors(VisualTestCase):
+    """
+    Test resolve_colors helper function
+    """
+
+    def test_resolve_colors_default(self):
+        """
+        Provides reasonable defaults provided no arguments
+        """
+        colors = resolve_colors()
+        assert colors == get_color_cycle()
+
+    def test_resolve_colors_default_truncate(self):
+        """
+        Truncates default colors when n_colors is smaller than palette
+        """
+        assert len(get_color_cycle()) > 3
+        assert len(resolve_colors(3)) == 3
+
+    def test_resolve_colors_default_multiply(self):
+        """
+        Multiplies default colors when n_colors is larger than palette
+        """
+        assert len(get_color_cycle()) < 18
+        assert len(resolve_colors(18)) == 18
+
+    def test_warning_on_colormap_and_colors_args(self):
+        """
+        Warns when both colormap and colors is used, colors is default
+        """
+        with pytest.warns(Warning, match="both colormap and colors specified"):
+            colors = resolve_colors(colormap='RdBu', colors=['r', 'g', 'b'])
+            assert colors == ['r', 'g', 'b']
+
+    def test_colormap_invalid(self):
+        """
+        Exception raised when invalid colormap is supplied
+        """
+        with pytest.raises(YellowbrickValueError):
+            resolve_colors(12, colormap='foo')
+
+    def test_colormap_string(self):
+        """
+        Check resolve colors works when a colormap string is passed
+        """
+        cases = (
+            (
+                {'n_colors': 6, 'colormap': 'RdBu'},
+                [
+                    (0.403921568627451, 0.0, 0.12156862745098039, 1.0),
+                    (0.8392156862745098, 0.3764705882352941, 0.30196078431372547, 1.0),
+                    (0.9921568627450981, 0.8588235294117647, 0.7803921568627451, 1.0),
+                    (0.8196078431372551, 0.8980392156862746, 0.9411764705882353, 1.0),
+                    (0.2627450980392157, 0.5764705882352941, 0.7647058823529411, 1.0),
+                    (0.0196078431372549, 0.18823529411764706, 0.3803921568627451, 1.0)
+                ],
+            ),
+            (
+                {'n_colors': 18, 'colormap': 'viridis'},
+                [
+                    (0.267004, 0.004874, 0.329415, 1.0),
+                    (0.281924, 0.089666, 0.412415, 1.0),
+                    (0.280255, 0.165693, 0.476498, 1.0),
+                    (0.263663, 0.237631, 0.518762, 1.0),
+                    (0.237441, 0.305202, 0.541921, 1.0),
+                    (0.208623, 0.367752, 0.552675, 1.0),
+                    (0.182256, 0.426184, 0.55712, 1.0),
+                    (0.159194, 0.482237, 0.558073, 1.0),
+                    (0.13777, 0.537492, 0.554906, 1.0),
+                    (0.121148, 0.592739, 0.544641, 1.0),
+                    (0.128087, 0.647749, 0.523491, 1.0),
+                    (0.180653, 0.701402, 0.488189, 1.0),
+                    (0.274149, 0.751988, 0.436601, 1.0),
+                    (0.395174, 0.797475, 0.367757, 1.0),
+                    (0.535621, 0.835785, 0.281908, 1.0),
+                    (0.688944, 0.865448, 0.182725, 1.0),
+                    (0.845561, 0.887322, 0.099702, 1.0),
+                    (0.993248, 0.906157, 0.143936, 1.0)
+                ],
+            ),
+            (
+                {'n_colors': 9, 'colormap': 'Set1'},
+                [
+                    (0.8941176470588236, 0.10196078431372549, 0.10980392156862745, 1.0),
+                    (0.21568627450980393, 0.49411764705882355, 0.7215686274509804, 1.0),
+                    (0.30196078431372547, 0.6862745098039216, 0.2901960784313726, 1.0),
+                    (0.596078431372549, 0.3058823529411765, 0.6392156862745098, 1.0),
+                    (1.0, 0.4980392156862745, 0.0, 1.0),
+                    (1.0, 1.0, 0.2, 1.0),
+                    (0.6509803921568628, 0.33725490196078434, 0.1568627450980392, 1.0),
+                    (0.9686274509803922, 0.5058823529411764, 0.7490196078431373, 1.0),
+                    (0.6, 0.6, 0.6, 1.0)
+                ],
+            ),
+        )
+
+        for kwds, expected in cases:
+            colors = resolve_colors(**kwds)
+            assert isinstance(colors, list)
+            assert colors == expected
+
+    def test_colormap_string_default_length(self):
+        """
+        Check colormap when n_colors is not specified
+        """
+        n_colors = len(get_color_cycle())
+        assert len(resolve_colors(colormap='autumn')) == n_colors
+
+    def test_colormap_cmap(self):
+        """
+        Assert that supplying a maptlotlib.cm as colormap works
+        """
+        cmap = cm.get_cmap('nipy_spectral')
+        colors = resolve_colors(4, colormap=cmap)
+        assert colors == [
+            (0.0, 0.0, 0.0, 1.0),
+            (0.0, 0.6444666666666666, 0.7333666666666667, 1.0),
+            (0.7999666666666666, 0.9777666666666667, 0.0, 1.0),
+            (0.8, 0.8, 0.8, 1.0)
+        ]
+
+    def test_colors(self):
+        """
+        Test passing in a list of colors
+        """
+        c = PALETTES['flatui']
+        assert resolve_colors(colors=c) == c
+
+    def test_colors_truncate(self):
+        """
+        Test passing in a list of colors with n_colors truncate
+        """
+        c = PALETTES['flatui']
+
+        assert len(c) > 3
+        assert len(resolve_colors(n_colors=3, colors=c)) == 3
+
+    def test_colors_multiply(self):
+        """
+        Test passing in a list of colors with n_colors multiply
+        """
+        c = PALETTES['flatui']
+
+        assert len(c) < 12
+        assert len(resolve_colors(n_colors=12, colors=c)) == 12

--- a/tests/test_style/test_colors.py
+++ b/tests/test_style/test_colors.py
@@ -30,19 +30,41 @@ from tests.base import VisualTestCase
 ## Color Tests
 ##########################################################################
 
-def test_get_color_cycle():
+class TestGetColorCycle(VisualTestCase):
     """
-    Test the retreival of the current color cycle
+    Test get_color_cycle helper function
     """
-    c = get_color_cycle()
-    assert len(c) == 6
 
-    with ColorPalette('paired'):
+    def test_cycle_depends_on_palette(self):
+        """
+        Ensure the color cycle depends on the palette
+        """
         c = get_color_cycle()
-        assert len(c) == 12
+        assert len(c) == 6
 
-    c = get_color_cycle()
-    assert len(c) == 6
+        with ColorPalette('paired'):
+            c = get_color_cycle()
+            assert len(c) == 12
+
+        c = get_color_cycle()
+        assert len(c) == 6
+
+    @pytest.mark.filterwarnings()
+    @pytest.mark.skipif(mpl_ge_150, reason="requires matplotlib 1.5 or later")
+    def test_mpl_ge_150(self):
+        """
+        Test get color cycle with matplotlib 1.5 or later
+        """
+        assert get_color_cycle() == mpl.rcParams['axes.color_cycle']
+
+
+    @pytest.mark.filterwarnings()
+    @pytest.mark.skipif(not mpl_ge_150, reason="requires matplotlib ealier than 1.5")
+    def test_mpl_lt_150(self):
+        """
+        Test get color cycle with matplotlib earlier than 1.5
+        """
+        assert get_color_cycle() == mpl.rcParams['axes.color_cycle']
 
 
 class TestResolveColors(VisualTestCase):

--- a/tests/test_style/test_palettes.py
+++ b/tests/test_style/test_palettes.py
@@ -17,7 +17,6 @@ Tests the palettes module of the yellowbrick library.
 ## Imports
 ##########################################################################
 
-import warnings
 import unittest
 import numpy as np
 import matplotlib as mpl
@@ -30,6 +29,7 @@ from yellowbrick.style.palettes import color_sequence, color_palette
 from yellowbrick.style.palettes import ColorPalette, PALETTES, SEQUENCES
 
 from tests.base import VisualTestCase
+
 
 ##########################################################################
 ## Color Palette Tests
@@ -270,16 +270,6 @@ class ColorPaletteFunctionTests(VisualTestCase):
 
         for rgb_e, rgb_v in zip(pal, pal.as_hex().as_rgb()):
             self.assertEqual(rgb_e, rgb_v)
-
-    def test_get_color_cycle(self):
-        """
-        Test getting the default color cycle
-        """
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            result = get_color_cycle()
-            expected = mpl.rcParams['axes.color_cycle']
-        self.assertEqual(result, expected)
 
     def test_preserved_palette_length(self):
         """

--- a/yellowbrick/classifier/boundaries.py
+++ b/yellowbrick/classifier/boundaries.py
@@ -343,7 +343,7 @@ class DecisionBoundariesVisualizer(ClassificationScoreVisualizer):
         X = self._select_feature_columns(X)
 
         color_cycle = iter(
-            resolve_colors(color=self.colors, num_colors=len(self.classes_)))
+            resolve_colors(colors=self.colors, n_colors=len(self.classes_)))
         colors = OrderedDict([(c, next(color_cycle))
                               for c in self.classes_.keys()])
 

--- a/yellowbrick/classifier/threshold.py
+++ b/yellowbrick/classifier/threshold.py
@@ -15,7 +15,6 @@ from sklearn.model_selection import train_test_split
 from sklearn.metrics import precision_recall_curve
 
 from yellowbrick.exceptions import YellowbrickTypeError
-from yellowbrick.style.palettes import get_color_cycle
 from yellowbrick.style.colors import resolve_colors
 from yellowbrick.base import ModelVisualizer
 from yellowbrick.utils import isclassifier
@@ -229,12 +228,8 @@ class ThresholdVisualizer(ModelVisualizer):
         self.ax : AxesSubplot of the visualizer
             Returns the AxesSubplot instance of the visualizer
         """
-        # set the colors
-        if self.color is not None:
-            color_values = resolve_colors(
-                num_colors=3, color=self.color)
-        else:
-            color_values = get_color_cycle()
+        # Set the colors from the supplied values or reasonable defaults
+        color_values = resolve_colors(n_colors=3, colors=self.color)
 
         uniform_thresholds = np.linspace(0, 1, num=101)
         uniform_precision_plots = []

--- a/yellowbrick/features/pcoords.py
+++ b/yellowbrick/features/pcoords.py
@@ -25,7 +25,7 @@ from sklearn.preprocessing import Normalizer, StandardScaler
 from yellowbrick.utils import is_dataframe
 from yellowbrick.features.base import DataVisualizer
 from yellowbrick.exceptions import YellowbrickTypeError, YellowbrickValueError
-from yellowbrick.style.colors import get_color_cycle
+from yellowbrick.style.colors import resolve_colors
 
 
 ##########################################################################
@@ -263,10 +263,9 @@ class ParallelCoordinates(DataVisualizer):
         # Create the colors
         # TODO: Allow both colormap, listed colors, and palette definition
         # TODO: Make this an independent function or property for override!
-        # color_values = resolve_colors(
-        #     num_colors=len(self.classes_), colormap=self.colormap, color=self.color
-        # )
-        color_values = get_color_cycle()
+        color_values = resolve_colors(
+            n_colors=len(self.classes_), colormap=self.colormap, colors=self.color
+        )
         colors = dict(zip(self.classes_, color_values))
 
         # Track which labels are already in the legend

--- a/yellowbrick/features/radviz.py
+++ b/yellowbrick/features/radviz.py
@@ -23,7 +23,7 @@ import matplotlib.patches as patches
 from yellowbrick.utils import is_dataframe
 from yellowbrick.features.base import DataVisualizer
 import yellowbrick.utils.nan_warnings as nan_warnings
-from yellowbrick.style.colors import get_color_cycle
+from yellowbrick.style.colors import resolve_colors
 
 
 ##########################################################################
@@ -176,10 +176,9 @@ class RadialVisualizer(DataVisualizer):
         # Create the colors
         # TODO: Allow both colormap, listed colors, and palette definition
         # TODO: Make this an independent function or property for override!
-        # color_values = resolve_colors(
-        #     num_colors=len(self.classes_), colormap=self.colormap, color=self.color
-        # )
-        color_values = get_color_cycle()
+        color_values = resolve_colors(
+            n_colors=len(self.classes_), colormap=self.colormap, colors=self.color
+        )
         colors = dict(zip(self.classes_, color_values))
 
         # Create a data structure to hold scatter plot representations

--- a/yellowbrick/features/scatter.py
+++ b/yellowbrick/features/scatter.py
@@ -22,7 +22,7 @@ from yellowbrick.features.base import DataVisualizer
 from yellowbrick.utils import is_dataframe, is_structured_array
 from yellowbrick.utils import has_ndarray_int_columns
 from yellowbrick.exceptions import YellowbrickValueError
-from yellowbrick.style.colors import resolve_colors, get_color_cycle
+from yellowbrick.style.colors import resolve_colors
 
 
 ##########################################################################
@@ -249,13 +249,11 @@ class ScatterVisualizer(DataVisualizer):
         self.ax.set_ylim([-1,1])
 
         # set the colors
-        if self.colormap is not None or self.color is not None:
-            color_values = resolve_colors(
-                num_colors=len(self.classes_),
-                colormap=self.colormap,
-                color=self.color)
-        else:
-            color_values = get_color_cycle()
+        color_values = resolve_colors(
+            n_colors=len(self.classes_),
+            colormap=self.colormap,
+            colors=self.color
+        )
 
         colors = dict(zip(self.classes_, color_values))
 

--- a/yellowbrick/style/colors.py
+++ b/yellowbrick/style/colors.py
@@ -54,58 +54,71 @@ def get_color_cycle():
     return mpl.rcParams['axes.color_cycle']
 
 
-def resolve_colors(num_colors=None, colormap=None, color=None):
+def resolve_colors(n_colors=None, colormap=None, colors=None):
     """
-    Resolves the colormap or the color list with the number of colors.
-    See: https://github.com/pydata/pandas/blob/master/pandas/tools/plotting.py#L163
+    Generates a list of colors based on common color arguments, for example
+    the name of a colormap or palette or another iterable of colors. The list
+    is then truncated (or multiplied) to the specific number of requested
+    colors.
 
     Parameters
     ----------
-    num_colors : int or None
-        the number of colors in the cycle or colormap
+    n_colors : int, default: None
+        Specify the length of the list of returned colors, which will either
+        truncate or multiple the colors available. If None the length of the
+        colors will not be modified.
 
-    colormap : str or None
-        the colormap used to create the sequence of colors
+    colormap : str, default: None
+        The name of the matplotlib color map with which to generate colors.
 
-    color : list or None
-        the list of colors to specifically use with the plot
+    colors : iterable, default: None
+        A collection of colors to use specifically with the plot.
 
+    Returns
+    -------
+    colors : list
+        A list of colors that can be used in matplotlib plots.
+
+    Notes
+    -----
+    This function was originally based on a similar function in the pandas
+    plotting library that has been removed in the new version of the library.
     """
 
-    # Work with the colormap
-    if color is None and colormap is None:
-        if isinstance(colormap, str):
-            cmap = colormap
-            colormap = cm.get_cmap(colormap)
+    # Work with the colormap if specified and colors is not
+    if colormap is not None and colors is None:
+        if isinstance(colormap, string_types):
+            try:
+                colormap = cm.get_cmap(colormap)
+            except ValueError as e:
+                raise YellowbrickValueError(e)
 
-            if colormap is None:
-                raise YellowbrickValueError(
-                    "Colormap {0} is not a valid matploblib cmap".format(cmap)
-                )
 
-        colors = list(map(colormap, np.linspace(0, 1, num=num_colors)))
+        n_colors = n_colors or len(get_color_cycle())
+        _colors = list(map(colormap, np.linspace(0, 1, num=n_colors)))
 
     # Work with the color list
-    elif color is not None:
+    elif colors is not None:
 
+        # Warn if both colormap and colors is specified.
         if colormap is not None:
             warnings.warn(
-                "'color' and 'colormap' cannot be used simultaneously! Using 'color'."
+                "both colormap and colors specified; using colors"
             )
 
-        colors = list(color) # Ensure colors is a list
+        _colors = list(colors) # Ensure colors is a list
 
     # Get the default colors
     else:
-        colors = get_color_cycle()
+        _colors = get_color_cycle()
 
-    if len(colors) != num_colors:
-        multiple = num_colors // len(colors) - 1
-        mod = num_colors % len(colors)
-        colors += multiple * colors
-        colors += colors[:mod]
+    # Truncate or multiple the color list according to the number of colors 
+    if n_colors is not None and len(_colors) != n_colors:
+        _colors = [
+            _colors[idx % len(_colors)] for idx in np.arange(n_colors)
+        ]
 
-    return colors
+    return _colors
 
 
 class ColorMap(object):
@@ -134,7 +147,7 @@ class ColorMap(object):
         Converts color strings into a color listing.
         """
         if isinstance(value, string_types):
-            # Must import here to avoid recursive import 
+            # Must import here to avoid recursive import
             from .palettes import PALETTES
 
             if value not in PALETTES:

--- a/yellowbrick/style/palettes.py
+++ b/yellowbrick/style/palettes.py
@@ -1,14 +1,33 @@
-# yellowbrick.style.palettes # Implements the variety of colors that yellowbrick allows access to by nam #
-# Author:   Patrick O'Melveny <pvomelveny@gmail.com# Author:   Benjamin Bengfort <bbengfort@districtdatalabs.com>  # Copyright (C) 2016 District Data Lab# For license information, see LICENSE.txt
-# D: palettes.py [] pvomelveny@gmail.com  "" Implements the variety of colors that yellowbrick allows access to by name This code was originally based on Seaborn's rcmody.py but has since beecleaned up to be Yellowbrick-specific and to dereference tools we don't use. Note that these functions alter the matplotlib rc dictionary on the fly.  ######################################################################### ## Import #########################################################################
+# yellowbrick.style.palettes
+# Implements the variety of colors that yellowbrick allows access to by name.
+#
+# Author:   Patrick O'Melveny <pvomelveny@gmail.com
+# Author:   Benjamin Bengfort <bbengfort@districtdatalabs.com>
+#
+# Copyright (C) 2016 District Data Lab
+# For license information, see LICENSE.txt
+#
+# ID: palettes.py [] pvomelveny@gmail.com
+
+"""
+Implements the variety of colors that yellowbrick allows access to by name.
+This code was originally based on Seaborn's rcmody.py but has since been
+cleaned up to be Yellowbrick-specific and to dereference tools we don't use.
+Note that these functions alter the matplotlib rc dictionary on the fly.
+"""
+
+#########################################################################
+## Imports
+#########################################################################
+
 from __future__ import division
-from itertools import cycle
 
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.colors as mplcol
 
+from itertools import cycle
 from six import string_types
 from six.moves import range
 


### PR DESCRIPTION
This PR provides fixes to the `resolve_colors` function and adds a test suite to guard against regression. I've also reimplemented `resolve_colors` on the feature visualizers that had it commented out to use `get_color_cycle` instead. 

This PR unblocks #321 -- however, a more extensive overhaul of color and color handling in YB is required. We have 4 different methodologies that are mixed and matched in kind of a strange fashion. More than that, Yellowbrick-specific requirements have emerged. Briefly, they are:

- We need discrete colors that are visually separate for classes 
- We need continuous colors for regression values and heatmaps 

Both of these requirements are specified by the target variable. Finally, we need helpers for the other utilities we use; but those can be largely handled with `resolve_colors` and `get_color_cycle`. 