### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,35 +16,35 @@ This README is a guide for developers, if you're new to Yellowbrick, get started
 
 ## What is Yellowbrick?
 
-Yellowbrick is a suite of visual diagnostic tools called "Visualizers" that extend the Scikit-Learn API to allow human steering of the model selection process. In a nutshell, Yellowbrick combines Scikit-Learn with Matplotlib in the best tradition of the Scikit-Learn documentation, but to produce visualizations for _your_ models!
+Yellowbrick is a suite of visual diagnostic tools called "Visualizers" that extend the scikit-learn API to allow human steering of the model selection process. In a nutshell, Yellowbrick combines scikit-learn with matplotlib in the best tradition of the scikit-learn documentation, but to produce visualizations for _your_ models!
 
 ![Visualizers](docs/images/visualizers.png)
 
 ### Visualizers
 
-Visualizers are estimators (objects that learn from data) whose primary objective is to create visualizations that allow insight into the model selection process. In Scikit-Learn terms, they can be similar to transformers when visualizing the data space or wrap an model estimator similar to how the "ModelCV" (e.g. RidgeCV, LassoCV) methods work. The primary goal of Yellowbrick is to create a sensical API similar to Scikit-Learn. Some of our most popular visualizers include:
+Visualizers are estimators (objects that learn from data) whose primary objective is to create visualizations that allow insight into the model selection process. In scikit-learn terms, they can be similar to transformers when visualizing the data space or wrapping a model estimator similar to how the "ModelCV" (e.g. RidgeCV, LassoCV) methods work. The primary goal of Yellowbrick is to create a sensical API similar to scikit-learn. Some of our most popular visualizers include:
 
 #### Feature Visualization
 
-- **Rank Features**: single or pairwise ranking of features to detect relationships
-- **Parallel Coordinates**: horizontal visualization of instances
-- **Radial Visualization**: separation of instances around a circular plot
-- **PCA Projection**: projection of instances based on principal components
 - **Feature Importances**: rank features based on their in-model performance 
+- **Parallel Coordinates**: horizontal visualization of instances
+- **PCA Projection**: projection of instances based on principal components
+- **RadViz**: separation of instances around a circular plot
+- **Rank Features**: single or pairwise ranking of features to detect relationships
 - **Scatter and Joint Plots**: direct data visualization with feature selection
 
 #### Classification Visualization
 
 - **Class Balance**: see how the distribution of classes affects the model
 - **Classification Report**: visual representation of precision, recall, and F1
-- **ROC/AUC Curves**: receiver operator characteristics and area under the curve
 - **Confusion Matrices**: visual description of class decision making
+- **ROC/AUC Curves**: receiver operator characteristics and area under the curve
 
 #### Regression Visualization
 
+- **Alpha Selection**: show how the choice of alpha influences regularization
 - **Prediction Error Plots**: find model breakdowns along the domain of the target
 - **Residuals Plot**: show the difference in residuals of training and test data
-- **Alpha Selection**: show how the choice of alpha influences regularization
 
 #### Clustering Visualization
 
@@ -56,21 +56,21 @@ Visualizers are estimators (objects that learn from data) whose primary objectiv
 - **Term Frequency**: visualize the frequency distribution of terms in the corpus
 - **TSNE**: use stochastic neighbor embedding to project documents.
 
-And more! Visualizers are being added all the time, be sure to check the examples (or even the develop branch) and feel free to contribute your ideas for Visualizers!
+And more! Visualizers are being added all the time, so be sure to check the examples (or even the develop branch) and feel free to contribute your ideas for Visualizers!
 
 ## Installing Yellowbrick
 
-Yellowbrick is compatible with Python 2.7 or later but it is preferred to use Python 3.5 or later to take full advantage of all functionality. Yellowbrick also depends on Scikit-Learn 0.18 or later and Matplotlib 1.5 or later. The simplest way to install Yellowbrick is from PyPI with pip, Python's preferred package installer.
+Yellowbrick is compatible with Python 2.7 or later but it is preferred to use Python 3.5 or later to take full advantage of all functionality. Yellowbrick also depends on scikit-learn 0.18 or later and matplotlib 1.5 or later. The simplest way to install Yellowbrick is from PyPI with pip, Python's preferred package installer.
 
     $ pip install yellowbrick
 
 Note that Yellowbrick is an active project and routinely publishes new releases with more visualizers and updates. In order to upgrade Yellowbrick to the latest version, use pip as follows.
 
-    $ pip install -u yellowbrick
+    $ pip install -U yellowbrick
 
-You can also use the `-u` flag to update Scikit-Learn, matplotlib, or any other third party utilities that work well with Yellowbrick to their latest versions.
+You can also use the `-U` flag to update scikit-learn, matplotlib, or any other third party utilities that work well with Yellowbrick to their latest versions.
 
-If you're using Windows or Anaconda, you can take advantage of the conda utility to install Yellowbrick:
+If you're using Anaconda, you can take advantage of the conda utility to install Yellowbrick:
 
     conda install -c districtdatalabs yellowbrick
 
@@ -78,11 +78,11 @@ Note, however, that there is a [known bug](https://github.com/DistrictDataLabs/y
 
 ## Using Yellowbrick
 
-The Yellowbrick API is specifically designed to play nicely with Scikit-Learn. Here is an example of a typical workflow sequence with Scikit-Learn and Yellowbrick:
+The Yellowbrick API is specifically designed to play nicely with scikit-learn. Here is an example of a typical workflow sequence with scikit-learn and Yellowbrick:
 
 ### Feature Visualization
 
-In this example, we see how Rank2D performs pairwise comparisons of each feature in the data set with a specific metric or algorithm, then returns them ranked as a lower left triangle diagram.
+In this example, we see how Rank2D performs pairwise comparisons of each feature in the data set with a specific metric or algorithm and then returns them ranked as a lower left triangle diagram.
 
 ```python
 from yellowbrick.features import Rank2D
@@ -95,7 +95,7 @@ visualizer.poof()                   # Draw/show/poof the data
 
 ### Model Visualization
 
-In this example, we instantiate a Scikit-Learn classifier, and then we use Yellowbrick's ROCAUC class to visualize the tradeoff between the classifier's sensitivity and specificity.
+In this example, we instantiate a scikit-learn classifier and then use Yellowbrick's ROCAUC class to visualize the tradeoff between the classifier's sensitivity and specificity.
 
 ```python
 from sklearn.svm import LinearSVC
@@ -116,7 +116,7 @@ We also have a [quick start guide](https://github.com/DistrictDataLabs/yellowbri
 
 Yellowbrick is an open source project that is supported by a community who will gratefully and humbly accept any contributions you might make to the project. Large or small, any contribution makes a big difference; and if you've never contributed to an open source project before, we hope you will start with Yellowbrick!
 
-Principally, Yellowbrick development is about the addition and creation of *visualizers* &mdash; objects that learn from data and create a visual representation of the data or model. Visualizers integrate with Scikit-Learn estimators, transformers, and pipelines for specific purposes and as a result, can be simple to build and deploy. The most common contribution is therefore a new visualizer for a specific model or model family. We'll discuss in detail how to build visualizers later.
+Principally, Yellowbrick development is about the addition and creation of *visualizers* -- objects that learn from data and create a visual representation of the data or model. Visualizers integrate with scikit-learn estimators, transformers, and pipelines for specific purposes and as a result can be simple to build and deploy. The most common contribution is therefore a new visualizer for a specific model or model family. We'll discuss in detail how to build visualizers later.
 
 Beyond creating visualizers, there are many ways to contribute:
 

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -5,11 +5,11 @@ About
 
 Image by QuatroCinco_, used with permission, Flickr Creative Commons.
 
-Yellowbrick is an open source, pure Python project that extends the Scikit-Learn API_ with visual analysis and diagnostic tools. The Yellowbrick API also wraps Matplotlib to create publication-ready figures and interactive data explorations while still allowing developers fine-grain control of figures. For users, Yellowbrick can help evaluate the performance, stability, and predictive value of machine learning models, and assist in diagnosing problems throughout the machine learning workflow.
+Yellowbrick is an open source, pure Python project that extends the scikit-learn API_ with visual analysis and diagnostic tools. The Yellowbrick API also wraps matplotlib to create publication-ready figures and interactive data explorations while still allowing developers fine-grain control of figures. For users, Yellowbrick can help evaluate the performance, stability, and predictive value of machine learning models and assist in diagnosing problems throughout the machine learning workflow.
 
 Recently, much of this workflow has been automated through grid search methods, standardized APIs, and GUI-based applications. In practice, however, human intuition and guidance can more effectively hone in on quality models than exhaustive search. By visualizing the model selection process, data scientists can steer towards final, explainable models and avoid pitfalls and traps.
 
-The Yellowbrick library is a diagnostic visualization platform for machine learning that allows data scientists to steer the model selection process. Yellowbrick extends the Scikit-Learn API with a new core object: the Visualizer. Visualizers allow visual models to be fit and transformed as part of the Scikit-Learn Pipeline process, providing visual diagnostics throughout the transformation of high dimensional data.
+The Yellowbrick library is a diagnostic visualization platform for machine learning that allows data scientists to steer the model selection process. It extends the scikit-learn API with a new core object: the Visualizer. Visualizers allow visual models to be fit and transformed as part of the scikit-learn pipeline process, providing visual diagnostics throughout the transformation of high-dimensional data.
 
 Model Selection
 ---------------
@@ -18,14 +18,10 @@ Discussions of machine learning are frequently characterized by a singular focus
 However, model selection is a bit more nuanced than simply picking the "right" or "wrong" algorithm. In practice, the workflow includes:
 
   1. selecting and/or engineering the smallest and most predictive feature set
-  2. choosing a set of algorithms from a model family, and
-  3. tuning the algorithm hyperparameters to optimize performance.
+  2. choosing a set of algorithms from a model family
+  3. tuning the algorithm hyperparameters to optimize performance
 
 The **model selection triple** was first described in a 2015 SIGMOD_ paper by Kumar et al. In their paper, which concerns the development of next-generation database systems built to anticipate predictive modeling, the authors cogently express that such systems are badly needed due to the highly experimental nature of machine learning in practice. "Model selection," they explain, "is iterative and exploratory because the space of [model selection triples] is usually infinite, and it is generally impossible for analysts to know a priori which [combination] will yield satisfactory accuracy and/or insights."
-
-Recently, much of this workflow has been automated through grid search methods, standardized APIs, and GUI-based applications. In practice, however, human intuition and guidance can more effectively hone in on quality models than exhaustive search. By visualizing the model selection process, data scientists can steer towards final, explainable models and avoid pitfalls and traps.
-
-The Yellowbrick library is a diagnostic visualization platform for machine learning that allows data scientists to steer the model selection process. Yellowbrick extends the Scikit-Learn API with a new core object: the Visualizer. Visualizers allow visual models to be fit and transformed as part of the Scikit-Learn Pipeline process, providing visual diagnostics throughout the transformation of high dimensional data.
 
 Name Origin
 -----------
@@ -37,9 +33,9 @@ From Wikipedia_:
 Team
 ----
 
-Yellowbrick is is developed by data scientists who believe in open source and the project enjoys contributions from Python developers all over the world. The project was started by `@rebeccabilbro`_ and `@bbengfort`_ as an attempt to better explain machine learning concepts to their students; they quickly realized, however, that the potential for visual steering could have a large impact on practical data science and developed it into a high-level Python library.
+Yellowbrick is developed by data scientists who believe in open source and the project enjoys contributions from Python developers all over the world. The project was started by `@rebeccabilbro`_ and `@bbengfort`_ as an attempt to better explain machine learning concepts to their students; they quickly realized, however, that the potential for visual steering could have a large impact on practical data science and developed it into a high-level Python library.
 
-Yellowbrick is incubated by `District Data Labs`_, an organization that is dedicated to collaboration and open source development. As part of District Data Labs, Yellowbrick was first introduced to the Python Community at `PyCon 2016 <https://youtu.be/c5DaaGZWQqY>`_ in both talks and during the development sprints. The project was then carried on through DDL Research Labs (semester-long sprints where members of the DDL community contribute to various data related projects).
+Yellowbrick is incubated by `District Data Labs`_, an organization that is dedicated to collaboration and open source development. As part of District Data Labs, Yellowbrick was first introduced to the Python Community at `PyCon 2016 <https://youtu.be/c5DaaGZWQqY>`_ in both talks and during the development sprints. The project was then carried on through DDL Research Labs (semester-long sprints where members of the DDL community contribute to various data-related projects).
 
 License
 -------
@@ -64,7 +60,6 @@ Yellowbrick has enjoyed the spotlight at a few conferences and in several presen
 
 Videos:
     - `Visual Diagnostics for More Informed Machine Learning: Within and Beyond Scikit-Learn (PyCon 2016) <https://youtu.be/c5DaaGZWQqY>`_
-    - `Visual Diagnostics for More Informed Machine Learning (PyData Carolinas 2016) <https://youtu.be/cgtNPx7fJUM>`_
     - `Yellowbrick: Steering Machine Learning with Visual Transformers (PyData London 2017) <https://youtu.be/2ZKng7pCB5k>`_
 
 Slides:

--- a/docs/api/anscombe.rst
+++ b/docs/api/anscombe.rst
@@ -3,7 +3,7 @@
 Anscombe's Quartet
 ==================
 
-Yellowbrick has learned Anscombe's lesson - which is why we believe that
+Yellowbrick has learned Anscombe's lesson---which is why we believe that
 visual diagnostics are vital to machine learning.
 
 .. code:: python

--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -5,14 +5,14 @@ Example Datasets
 
 Yellowbrick hosts several datasets wrangled from the `UCI Machine
 Learning Repository <http://archive.ics.uci.edu/ml/>`__ to present the
-examples in this section. If you haven't downloaded the data, you can do so by
+examples used throughout this documentation. If you haven't downloaded the data, you can do so by
 running:
 
 ::
 
     $ python -m yellowbrick.download
 
-This should create a folder called ``data`` in your current working directory with all of the datasets. You can load a specified dataset with ``pandas.read_csv`` as follows:
+This should create a folder named ``data`` in your current working directory that contains all of the datasets. You can load a specified dataset with ``pandas.read_csv`` as follows:
 
 .. code:: python
 
@@ -20,10 +20,12 @@ This should create a folder called ``data`` in your current working directory wi
 
     data = pd.read_csv('data/concrete/concrete.csv')
 
-The following code snippet can be found at the top of the ``examples/examples.ipynb`` notebok in Yellowbrick. Please reference this code when trying to load a specific data set:
+The following code snippet can be found at the top of the ``examples/examples.ipynb`` notebook in Yellowbrick. Please reference this code when trying to load a specific data set:
 
 .. code:: python
 
+    import os
+    
     from yellowbrick.download import download_all
 
     ## The path to the test data sets
@@ -64,8 +66,8 @@ The following code snippet can be found at the top of the ``examples/examples.ip
         # Return the data frame
         return pd.read_csv(path)
 
-Note that most of the examples currently use one or more of the listed datasets for their examples (unless specifically shown otherwise). Each dataset has a ``README.md`` with detailed information about the data source, attributes, and target. Here is a complete listing of all datasets in Yellowbrick and their associated analytical tasks:
 
+Unless otherwise specified, most of the examples currently use one or more of the listed datasets. Each dataset has a ``README.md`` with detailed information about the data source, attributes, and target. Here is a complete listing of all datasets in Yellowbrick and their associated analytical tasks:
 - **bikeshare**: suitable for regression
 - **concrete**: suitable for regression
 - **credit**: suitable for classification/clustering

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -3,7 +3,7 @@
 Visualizers and API
 ===================
 
-Welcome the API documentation for Yellowbrick! This section contains a complete listing of all currently available, production-ready visualizers along with code examples of how to use them. Use the links below to navigate to the reference for each visualization.
+Welcome to the API documentation for Yellowbrick! This section contains a complete listing of the currently available, production-ready visualizers along with code examples of how to use them. You may use the following links to navigate to the reference material for each visualization.
 
 .. toctree::
    :maxdepth: 2
@@ -17,8 +17,8 @@ Welcome the API documentation for Yellowbrick! This section contains a complete 
    text/index
    palettes
 
-.. note:: Many examples utilize data from the UCI Machine Learning repository, in order to run the examples, make sure you follow the instructions in :doc:`datasets` to download and load required data.
+.. note:: Many examples utilize data from the UCI Machine Learning repository. In order to run the accompanying code, make sure to follow the instructions in :doc:`datasets` to download and load the required data.
 
 A guide to finding the visualizer you're looking for: generally speaking, visualizers can be data visualizers which visualize instances relative to the model space; score visualizers which visualize model performance; model selection visualizers which compare multiple model forms against each other; and application specific-visualizers. This can be a bit confusing, so we've grouped visualizers according to the type of analysis they are well suited for.
 
-Feature analysis visualizers are where you'll find the primary implementation of data visualizers. Regression, classification, and clustering analysis visualizers can be found in their respective libraries. Finally visualizers for text analysis are also available in Yellowbrick! Other utilities like styles, best fit lines, and anscombe's visualization can also be found in the links above.
+Feature analysis visualizers are where you'll find the primary implementation of data visualizers. Regression, classification, and clustering analysis visualizers can be found in their respective libraries. Finally, visualizers for text analysis are also available in Yellowbrick! Other utilities, such as styles, best fit lines, and Anscombe's visualization, can also be found in the links above.

--- a/docs/api/palettes.rst
+++ b/docs/api/palettes.rst
@@ -3,9 +3,9 @@
 Colors and Style
 ================
 
-Yellowbrick believes that visual diagnostics are more effective if visualizations are appealing. As a result, we have borrowed familiar styles from `Seaborn <http://seaborn.pydata.org/tutorial/aesthetics.html>`_ and use the new `Matplotlib 2.0 styles <https://matplotlib.org/users/colormaps.html>`_. We hope that these out of the box styles will make your visualizations publication ready, though of course you can customize your own look and feel by directly modifying the visualization with matplotlib.
+Yellowbrick believes that visual diagnostics are more effective if visualizations are appealing. As a result, we have borrowed familiar styles from `Seaborn <http://seaborn.pydata.org/tutorial/aesthetics.html>`_ and use the new `matplotlib 2.0 styles <https://matplotlib.org/users/colormaps.html>`_. We hope that these out-of-the-box styles will make your visualizations publication ready, though you can also still customize your own look and feel by directly modifying the visualizations with matplotlib.
 
-Yellowbrick prioritizes color in its visualizations for most visualizers. There are two types of color sets that can be provided to a visualizer: a palette and a sequence. Palettes are discrete color values usually of a fixed length and are typically used for classification or clustering by showing each class, cluster or topic. Sequences are continuous color values that do not have a fixed length but rather a range and are typically used for regression or clustering, showing all possible values in the target or distances between items in clusters.
+For most visualizers, Yellowbrick prioritizes color in its visualizations. There are two types of color sets that can be provided to a visualizer: a palette and a sequence. Palettes are discrete color values usually of a fixed length and are typically used for classification or clustering by showing each class, cluster, or topic. Sequences are continuous color values that do not have a fixed length but rather a range and are typically used for regression or clustering, showing all possible values in the target or distances between items in clusters.
 
 In order to make the distinction easy, most matplotlib colors (both palettes and sequences) can be referred to by name. A complete listing can be imported as follows:
 
@@ -20,12 +20,12 @@ Palettes and sequences can be passed to visualizers as follows:
 
     visualizer = Visualizer(color="bold")
 
-Refer to the API listing of each visualizer for specifications about how each color argument is handled. In the next two sections we will show every possible color palette and sequence currently available in Yellowbrick.
+Refer to the API listing of each visualizer for specifications on how the color argument is handled. In the next two sections, we will show every possible color palette and sequence currently available in Yellowbrick.
 
 Color Palettes
 --------------
 
-Color palettes are discrete color lists that have a fixed length. The most common palettes are ordered as "blue", "green", "red", "maroon", "yellow", "cyan", and an optional "key". This allows you to specify these named colors or by the first character, e.g. 'bgrmyck' for matplotlib visualizations.
+Color palettes are discrete color lists that have a fixed length. The most common palettes are ordered as "blue", "green", "red", "maroon", "yellow", "cyan", and an optional "key". This allows you to specify these named colors by the first character, e.g. 'bgrmyck' for matplotlib visualizations.
 
 To change the global color palette, use the `set_palette` function as follows:
 
@@ -117,7 +117,7 @@ A complete listing of the Yellowbrick color palettes can be visualized as follow
 Color Sequences
 ---------------
 
-Color sequences are continuous representations of color and are usually defined as a fixed number of steps between a minimum and maximal value. Sequences must be created with a total number of bins (or length) before plotting to ensure that values are assigned correctly. In the listing below, each sequence is shown with varying lengths to describe the range of colors in detail.
+Color sequences are continuous representations of color and are usually defined as a fixed number of steps between a minimum and maximal value. Sequences must be created with a total number of bins (or length) before plotting to ensure that the values are assigned correctly. In the listing below, each sequence is shown with varying lengths to describe the range of colors in detail.
 
 Color sequences are most often used in regressions to show the distribution in the range of target values. They can also be used in clustering and distribution analysis to show distance or histogram data.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,16 +12,16 @@ Version 0.5
 
 Changes:
     - Added VisualTestCase.
-    - New PCADecomposition Visualizer, which decomposes high dimensional data into two or three dimensions so that each instance can be plotted in a scatter plot.
+    - New PCADecomposition Visualizer, which decomposes high-dimensional data into two or three dimensions so that each instance can be plotted in a scatter plot.
     - New and improved ROCAUC Visualizer, which now supports multiclass classification.
     - Prototype Decision Boundary Visualizer, which is a bivariate data visualization algorithm that plots the decision boundaries of each class.
-    - Added Rank1D Visualizer, which is a one dimensional ranking of features that utilizes the Shapiro-Wilks ranking that takes into account only a single feature at a time (e.g. histogram analysis).
-    - Improved Prediction Error Plot with identity line, shared limits, and r squared.
+    - Added Rank1D Visualizer, which is a one-dimensional ranking of features that utilizes the Shapiro-Wilks ranking by taking into account only a single feature at a time (e.g. histogram analysis).
+    - Improved Prediction Error Plot with identity line, shared limits, and R-squared.
     - Updated FreqDist Visualizer to make word features a hyperparameter.
     - Added normalization and scaling to Parallel Coordinates.
     - Added Learning Curve Visualizer, which displays a learning curve based on the number of samples versus the training and cross validation scores to show how a model learns and improves with experience.
-    - Added data downloader module to the yellowbrick library.
-    - Complete overhaul of the yellowbrick documentation; categories of methods are located in separate pages to make it easier to read and contribute to the documentation.
+    - Added data downloader module to the Yellowbrick library.
+    - Complete overhaul of the Yellowbrick documentation; categories of methods are located in separate pages to make it easier to read and contribute to the documentation.
     - Added a new color palette inspired by `ANN-generated colors <http://lewisandquark.tumblr.com/>`_
 
 Bug Fixes:
@@ -48,13 +48,13 @@ This release is an intermediate version bump in anticipation of the PyCon 2017 s
 
 The primary goals of this version were to (1) update the Yellowbrick dependencies (2) enhance the Yellowbrick documentation to help orient new users and contributors, and (3) make several small additions and upgrades (e.g. pulling the Yellowbrick utils into a standalone module).
 
-We have updated the Scikit-Learn and SciPy dependencies from version 0.17.1 or later to 0.18 or later. This primarily entails moving from ``from sklearn.cross_validation import train_test_split`` to ``from sklearn.model_selection import train_test_split``.
+We have updated the scikit-learn and SciPy dependencies from version 0.17.1 or later to 0.18 or later. This primarily entails moving from ``from sklearn.cross_validation import train_test_split`` to ``from sklearn.model_selection import train_test_split``.
 
-The updates to the documentation include new Quickstart and Installation guides as well as updates to the Contributors documentation, which is modeled on the Scikit-Learn contributing documentation.
+The updates to the documentation include new Quickstart and Installation guides, as well as updates to the Contributors documentation, which is modeled on the scikit-learn contributing documentation.
 
-This version also included upgrades to the KMeans visualizer, which now supports not only ``silhouette_score`` but also ``distortion_score`` and ``calinski_harabaz_score``. The ``distortion_score`` computes the mean distortion of all samples as the sum of the squared distances between each observation and its closest centroid. This is the metric that K-Means attempts to minimize as it is fitting the model. The ``calinski_harabaz_score`` is defined as ratio between the within-cluster dispersion and the between-cluster dispersion.
+This version also included upgrades to the KMeans visualizer, which now supports not only ``silhouette_score`` but also ``distortion_score`` and ``calinski_harabaz_score``. The ``distortion_score`` computes the mean distortion of all samples as the sum of the squared distances between each observation and its closest centroid. This is the metric that KMeans attempts to minimize as it is fitting the model. The ``calinski_harabaz_score`` is defined as ratio between the within-cluster dispersion and the between-cluster dispersion.
 
-Finally, this release includes a prototype of the ``VisualPipeline``, which extends Scikit-Learn's ``Pipeline`` class, allowing multiple Visualizers to be chained or sequenced together.
+Finally, this release includes a prototype of the ``VisualPipeline``, which extends scikit-learn's ``Pipeline`` class, allowing multiple Visualizers to be chained or sequenced together.
 
 * Tag: v0.4.1_
 * Deployed: Monday, May 22, 2017
@@ -62,7 +62,7 @@ Finally, this release includes a prototype of the ``VisualPipeline``, which exte
 
 Changes:
    - Score and model visualizers now wrap estimators as proxies so that all methods on the estimator can be directly accessed from the visualizer
-   - Updated Scikit-learn dependency from >=0.17.1  to >=0.18
+   - Updated scikit-learn dependency from >=0.17.1  to >=0.18
    - Replaced ``sklearn.cross_validation`` with ``model_selection``
    - Updated SciPy dependency from >=0.17.1 to >=0.18
    - ScoreVisualizer now subclasses ModelVisualizer; towards allowing both fitted and unfitted models passed to Visualizers
@@ -73,7 +73,7 @@ Changes:
    - Replaced the ``self.ax`` property on all of the individual ``draw`` methods with a new property on the ``Visualizer`` class that ensures all visualizers automatically have axes.
    - Refactored the utils module into a package
    - Continuing to update the docstrings to conform to Sphinx
-   - Added a prototype visual pipeline class that extends the Scikit-learn pipeline class to ensure that visualizers get called correctly.
+   - Added a prototype visual pipeline class that extends the scikit-learn pipeline class to ensure that visualizers get called correctly.
 
 Bug Fixes:
    - Fixed title bug in Rank2D FeatureVisualizer
@@ -89,7 +89,7 @@ Notable in this release is the inclusion of two new feature visualizers that use
 
 This release also adds support for clustering visualizations, namely the elbow method for selecting K, ``KElbowVisualizer`` and a visualization of cluster size and density using the ``SilhouetteVisualizer``. The release also adds support for regularization analysis using the ``AlphaSelection`` visualizer. Both the text and classification modules were also improved with the inclusion of the ``PosTagVisualizer`` and the ``ConfusionMatrix`` visualizer respectively.
 
-This release also added an Anaconda repository and distribution so that users can ``conda install`` yellowbrick. Even more notable, we got yellowbrick stickers! We've also updated the documentation to make it more friendly and a bit more visual; fixing the API rendering errors. All-in-all, this was a big release with a lot of contributions and we thank everyone that participated in the lab!
+This release also added an Anaconda repository and distribution so that users can ``conda install`` yellowbrick. Even more notable, we got Yellowbrick stickers! We've also updated the documentation to make it more friendly and a bit more visual; fixing the API rendering errors. All-in-all, this was a big release with a lot of contributions and we thank everyone that participated in the lab!
 
 * Tag: v0.4_
 * Deployed: Thursday, May 4, 2017
@@ -140,7 +140,7 @@ Changes:
 
 Version 0.3.2
 -------------
-Hardened the Yellowbrick API to elevate the idea of a Visualizer to a first principle. This included reconciling shifts in the development of the preliminary versions to the new API, formalizing Visualizer methods like `draw()` and `finalize()`, and adding utilities that revolve around Scikit-Learn. To that end we also performed administrative tasks like refreshing the documentation and preparing the repository for more and varied open source contributions.
+Hardened the Yellowbrick API to elevate the idea of a Visualizer to a first principle. This included reconciling shifts in the development of the preliminary versions to the new API, formalizing Visualizer methods like `draw()` and `finalize()`, and adding utilities that revolve around scikit-learn. To that end we also performed administrative tasks like refreshing the documentation and preparing the repository for more and varied open source contributions.
 
 * Tag: v0.3.2_
 * Deployed: Friday, January 20, 2017
@@ -174,9 +174,9 @@ Hotfix to solve pip install issues with Yellowbrick.
 
 Version 0.3
 -----------
-This release marks a major change from the previous MVP releases as Yellowbrick moves towards direct integration with Scikit-Learn for visual diagnostics and steering of machine learning and could therefore be considered the first alpha release of the library. To that end we have created a Visualizer model which extends sklearn.base.BaseEstimator and can be used directly in the ML Pipeline. There are a number of visualizers that can be used throughout the model selection process, including for feature analysis, model selection, and hyperparameter tuning.
+This release marks a major change from the previous MVP releases as Yellowbrick moves towards direct integration with scikit-learn for visual diagnostics and steering of machine learning and could therefore be considered the first alpha release of the library. To that end we have created a Visualizer model which extends sklearn.base.BaseEstimator and can be used directly in the ML Pipeline. There are a number of visualizers that can be used throughout the model selection process, including for feature analysis, model selection, and hyperparameter tuning.
 
-In this release specifically we focused on visualizers in the data space for feature analysis and visualizers in the model space for scoring and evaluating models. Future releases will extend these base classes and add more functionality.
+In this release specifically, we focused on visualizers in the data space for feature analysis and visualizers in the model space for scoring and evaluating models. Future releases will extend these base classes and add more functionality.
 
 * Tag: v0.3_
 * Deployed: Sunday, October 9, 2016
@@ -186,28 +186,28 @@ In this release specifically we focused on visualizers in the data space for fea
    - Created an API for visualization with machine learning: Visualizers that are BaseEstimators.
    - Created a class hierarchy for Visualizers throughout the ML process particularly feature analysis and model evaluation
    - Visualizer interface is draw method which can be called multiple times on data or model spaces and a poof method to finalize the figure and display or save to disk.
-   - ScoreVisualizers wrap Scikit-Learn estimators and implement fit and predict (pass-throughs to the estimator) and also score which calls draw in order to visually score the estimator. If the estimator isn't appropriate for the scoring method an exception is raised.
+   - ScoreVisualizers wrap scikit-learn estimators and implement fit and predict (pass-throughs to the estimator) and also score which calls draw in order to visually score the estimator. If the estimator isn't appropriate for the scoring method an exception is raised.
    - ROCAUC is a ScoreVisualizer that plots the receiver operating characteristic curve and displays the area under the curve score.
    - ClassificationReport is a ScoreVisualizer that renders the confusion matrix of a classifier as a heatmap.
    - PredictionError is a ScoreVisualizer that plots the actual vs. predicted values and the 45 degree accuracy line for regressors.
    - ResidualPlot is a ScoreVisualizer that plots the residuals (y - yhat) across the actual values (y) with the zero accuracy line for both train and test sets.
    - ClassBalance is a ScoreVisualizer that displays the support for each class as a bar plot.
-   - FeatureVisualizers are Scikit-Learn Transformers that implement fit and transform and operate on the data space, calling draw to display instances.
+   - FeatureVisualizers are scikit-learn Transformers that implement fit and transform and operate on the data space, calling draw to display instances.
    - ParallelCoordinates plots instances with class across each feature dimension as line segments across a horizontal space.
    - RadViz plots instances with class in a circular space where each feature dimension is an arc around the circumference and points are plotted relative to the weight of the feature.
    - Rank2D plots pairwise scores of features as a heatmap in the space [-1, 1] to show relative importance of features. Currently implemented ranking functions are Pearson correlation and covariance.
    - Coordinated and added palettes in the bgrmyck space and implemented a version of the Seaborn set_palette and set_color_codes functions as well as the ColorPalette object and other matplotlib.rc modifications.
-   - Inherited Seaborn's notebook context and whitegrid axes style but make them the default, don't allow user to modify (if they'd like to, they'll have to import Seaborn). This gives Yellowbrick a consistent look and feel without giving too much work to the user and prepares us for Matplotlib 2.0.
+   - Inherited Seaborn's notebook context and whitegrid axes style but make them the default, don't allow user to modify (if they'd like to, they'll have to import Seaborn). This gives Yellowbrick a consistent look and feel without giving too much work to the user and prepares us for matplotlib 2.0.
    - Jupyter Notebook with Examples of all Visualizers and usage.
 
   Bug Fixes:
    - Fixed Travis-CI test failures with matplotlib.use('Agg').
    - Fixed broken link to Quickstart on README
-   - Refactor of the original API to the Scikit-Learn Visualizer API
+   - Refactor of the original API to the scikit-learn Visualizer API
 
 Version 0.2
 -----------
-Intermediate steps towards a complete API for visualization. Preparatory stages for Scikit-Learn visual pipelines.
+Intermediate steps towards a complete API for visualization. Preparatory stages for scikit-learn visual pipelines.
 
 * Tag: v0.2_
 * Deployed: Sunday, September 4, 2016

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -11,45 +11,32 @@ options and customize as much as possible. After you've exercised the
 code with your examples, respond to our `alpha testing
 survey <https://goo.gl/forms/naoPUMFa1xNcafY83>`__!
 
-Step One: Questionaire
-~~~~~~~~~~~~~~~~~~~~~~
-Please open the quesionaire, in order to familiarize yourself with the
-feedback that we are looking to receive. We are very interested in
-identifying any bugs in Yellowbrick. Please include al cells in your
-jupyter notebook that produce errors so that we may reproduce the
+Step One: Questionnaire
+~~~~~~~~~~~~~~~~~~~~~~~
+Please open the questionnaire, in order to familiarize yourself with the
+type of feedback we are looking to receive. We are very interested in
+identifying any bugs in Yellowbrick. Please include any cells in your
+Jupyter notebook that produce errors so that we may reproduce the
 problem.
 
 
 Step Two: Dataset
 ~~~~~~~~~~~~~~~~~
 
-Select a multivariate dataset of your own; the more (e.g. different)
-datasets that we can run through Yellowbrick, the more likely we'll
-discover edge cases and exceptions! Note that your dataset must be
-well-suited to modeling with Scikit-Learn. In particular we recommend
-you choose a dataset whose target is suited to the following supervised
-learning tasks:
+Select a multivariate dataset of your own. The greater the variety of datasets that we can run through Yellowbrick, the more likely we'll discover edge cases and exceptions! Please note that your dataset must be well-suited to modeling with scikit-learn. In particular, we recommend choosing a dataset whose target is suited to one of the following supervised learning tasks:
 
 -  `Regression <https://en.wikipedia.org/wiki/Regression_analysis>`__
    (target is a continuous variable)
 -  `Classification <https://en.wikipedia.org/wiki/Classification_in_machine_learning>`__
    (target is a discrete variable)
 
-There are datasets that are well suited to both types of analysis;
-either way you can use the testing methodology from this notebook for
-either type of task (or both). In order to find a dataset, we recommend
-you try the following places:
+There are datasets that are well suited to both types of analysis; either way, you can use the testing methodology from this notebook for either type of task (or both). In order to find a dataset, we recommend you try the following places:
 
 -  `UCI Machine Learning Repository <http://archive.ics.uci.edu/ml/>`__
 -  `MLData.org <http://mldata.org/>`__
--  `Awesome Public
-   Datasets <https://github.com/caesar0301/awesome-public-datasets>`__
+-  `Awesome Public Datasets <https://github.com/caesar0301/awesome-public-datasets>`__
 
-You're more than welcome to choose a dataset of your own, but we do ask
-that you make at least the notebook containing your testing results
-publicly available for us to review. If the data is also public (or
-you're willing to share it with the primary contributors) that will help
-us figure out bugs and required features much more easily!
+You're more than welcome to choose a dataset of your own, but we do ask that you make at least the notebook containing your testing results publicly available for us to review. If the data is also public (or you're willing to share it with the primary contributors) that will help us figure out bugs and required features much more easily!
 
 Step Three: Notebook
 ~~~~~~~~~~~~~~~~~~~~
@@ -57,13 +44,10 @@ Step Three: Notebook
 Create a notebook in a GitHub repository. We suggest the following:
 
 1. Fork the Yellowbrick repository
-2. Under the ``examples`` directory, create a directory named with your
-   GitHub username
+2. Under the ``examples`` directory, create a directory named with your GitHub username
 3. Create a notebook named ``testing``, i.e. examples/USERNAME/testing.ipynb
 
-Alternatively, you could just send us a notebook via Gist or your own
-repository. However, if you fork Yellowbrick, you can initiate a pull
-request to have your example added to our gallery!
+Alternatively, you could just send us a notebook via Gist or your own repository. However, if you fork Yellowbrick, you can initiate a pull request to have your example added to our gallery!
 
 Step Four: Model with Yellowbrick and Scikit-Learn
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -76,17 +60,12 @@ Add the following to the notebook:
 
 Then conduct the following modeling activities:
 
--  Feature analysis using Scikit-Learn and Yellowbrick
--  Estimator fitting using Scikit-Learn and Yellowbrick
+-  Feature analysis using scikit-learn and Yellowbrick
+-  Estimator fitting using scikit-learn and Yellowbrick
 
-You can follow along with our ``examples`` directory (check out
-`examples.ipynb <https://github.com/DistrictDataLabs/yellowbrick/blob/master/examples/examples.ipynb>`__)
-or even create your own custom visualizers! The goal is that you create
-an end-to-end model from data loading to estimator(s) with visualizers
-along the way.
+You can follow along with our ``examples`` directory (check out `examples.ipynb <https://github.com/DistrictDataLabs/yellowbrick/blob/master/examples/examples.ipynb>`__) or even create your own custom visualizers! The goal is that you create an end-to-end model from data loading to estimator(s) with visualizers along the way.
 
-**IMPORTANT**: please make sure you record all errors that you get and
-any tracebacks you receive for step three!
+**IMPORTANT**: please make sure you record all errors that you get and any tracebacks you receive for step three!
 
 Step Five: Feedback
 ~~~~~~~~~~~~~~~~~~~
@@ -95,16 +74,9 @@ Finally, submit feedback via the Google Form we have created:
 
 https://goo.gl/forms/naoPUMFa1xNcafY83
 
-This form is allowing us to aggregate multiple submissions and bugs so
-that we can coordinate the creation and management of issues. If you are
-the first to report a bug or feature request, we will make sure you're
-notified (we'll tag you using your Github username) about the created
-issue!
+This form is allowing us to aggregate multiple submissions and bugs so that we can coordinate the creation and management of issues. If you are the first to report a bug or feature request, we will make sure you're notified (we'll tag you using your Github username) about the created issue!
 
 Step Six: Thanks!
 ~~~~~~~~~~~~~~~~~
 
-Thank you for helping us make Yellowbrick better! We'd love to see pull
-requests for features you think would be extend the library. We'll also
-be doing a user study that we would love for you to participate in. Stay
-tuned for more great things from Yellowbrick!
+Thank you for helping us make Yellowbrick better! We'd love to see pull requests for features you think should be added to the library. We'll also be doing a user study that we would love for you to participate in. Stay tuned for more great things from Yellowbrick!

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,11 +3,11 @@
 Quick Start
 ===========
 
-If you're new to Yellowbrick, this guide will get you started and help you include visualizers in your machine learning workflow. Before we get started, however, there are several notes about development environments that you should consider.
+If you're new to Yellowbrick, this guide will get you started and help you include visualizers in your machine learning workflow. Before we begin, however, there are several notes about development environments that you should consider.
 
-Yellowbrick has two primary dependencies: `Scikit-Learn <http://scikit-learn.org/>`_ and `Matplotlib <http://matplotlib.org/>`_. If you do not have these Python packages, they will be installed alongside Yellowbrick. Note that Yellowbrick works best with Scikit-Learn version 0.18 or later and Matplotlib version 2.0 or later. Both of these packages require some C code to be compiled, which can be difficult on some systems, like Windows. If you're having trouble, try using a distribution of Python that includes these packages like `Anaconda <https://anaconda.org>`_.
+Yellowbrick has two primary dependencies: `scikit-learn <http://scikit-learn.org/>`_ and `matplotlib <http://matplotlib.org/>`_. If you do not have these Python packages, they will be installed alongside Yellowbrick. Note that Yellowbrick works best with scikit-learn version 0.18 or later and matplotlib version 2.0 or later. Both of these packages require some C code to be compiled, which can be difficult on some systems, like Windows. If you're having trouble, try using a distribution of Python that includes these packages like `Anaconda <https://anaconda.org>`_.
 
-Yellowbrick is also commonly used inside of a `Jupyter Notebook <http://jupyter.org/>`_ alongside `Pandas <http://pandas.pydata.org/>`_ data frames. Notebooks make it especially easy to coordinate code and visualizations, however you can also use Yellowbrick inside of regular Python scripts, either saving figures to disk or showing figures in a GUI window. If you're having trouble with this, please consult Matplotlib's `backends documentation <https://matplotlib.org/faq/usage_faq.html#what-is-a-backend>`_.
+Yellowbrick is also commonly used inside of a `Jupyter Notebook <http://jupyter.org/>`_ alongside `Pandas <http://pandas.pydata.org/>`_ data frames. Notebooks make it especially easy to coordinate code and visualizations; however, you can also use Yellowbrick inside of regular Python scripts, either saving figures to disk or showing figures in a GUI window. If you're having trouble with this, please consult matplotlib's `backends documentation <https://matplotlib.org/faq/usage_faq.html#what-is-a-backend>`_.
 
 .. NOTE:: Jupyter, Pandas, and other ancillary libraries like NLTK for text visualizers are not installed with Yellowbrick and must be installed separately.
 
@@ -27,11 +27,11 @@ Note that Yellowbrick is an active project and routinely publishes new releases 
 
 .. code-block:: bash
 
-    $ pip install -u yellowbrick
+    $ pip install -U yellowbrick
 
-You can also use the ``-u`` flag to update Scikit-Learn, matplotlib, or any other third party utilities that work well with Yellowbrick to their latest versions.
+You can also use the ``-U`` flag to update scikit-learn, matplotlib, or any other third party utilities that work well with Yellowbrick to their latest versions.
 
-If you're using Windows or Anaconda, you can take advantage of the `conda <https://conda.io/docs/intro.html>`_ utility to install the `Anaconda Yellowbrick package <https://anaconda.org/DistrictDataLabs/yellowbrick>`_:
+If you're using Anaconda, you can take advantage of the `conda <https://conda.io/docs/intro.html>`_ utility to install the `Anaconda Yellowbrick package <https://anaconda.org/DistrictDataLabs/yellowbrick>`_:
 
 .. code-block:: bash
 
@@ -43,9 +43,9 @@ Once installed, you should be able to import Yellowbrick without an error, both 
 
 Using Yellowbrick
 -----------------
-The Yellowbrick API is specifically designed to play nicely with Scikit-Learn. The primary interface is therefore a ``Visualizer`` -- an object that learns from data to produce a visualization. Visualizers are Scikit-Learn `Estimator <http://scikit-learn.org/stable/developers/contributing.html#apis-of-scikit-learn-objects>`_ objects and have a similar interface along with methods for drawing. In order to use visualizers, you simply use the same workflow as with a Scikit-Learn model, import the visualizer, instantiate it, call the visualizer's ``fit()`` method, then in order to render the visualization, call the visualizer's ``poof()`` method, which does the magic!
+The Yellowbrick API is specifically designed to play nicely with scikit-learn. The primary interface is therefore a ``Visualizer`` -- an object that learns from data to produce a visualization. Visualizers are scikit-learn `Estimator <http://scikit-learn.org/stable/developers/contributing.html#apis-of-scikit-learn-objects>`_ objects and have a similar interface along with methods for drawing. In order to use visualizers, you simply use the same workflow as with a scikit-learn model, import the visualizer, instantiate it, call the visualizer's ``fit()`` method, then in order to render the visualization, call the visualizer's ``poof()`` method, which does the magic!
 
-For example, there are several visualizers that act as transformers, used to perform feature analysis prior to fitting a model. Here is an example to visualize a high dimensional data set with parallel coordinates:
+For example, there are several visualizers that act as transformers, used to perform feature analysis prior to fitting a model. The following example visualizes a high-dimensional data set with parallel coordinates:
 
 .. code-block:: python
 
@@ -55,7 +55,7 @@ For example, there are several visualizers that act as transformers, used to per
     visualizer.fit_transform(X, y)
     visualizer.poof()
 
-As you can see, the workflow is very similar to using a Scikit-Learn transformer, and visualizers are intended to be integrated along with Scikit-Learn utilities. Arguments that change how the visualization is drawn can be passed into the visualizer upon instantiation, similarly to how hyperparameters are included with Scikit-Learn models.
+As you can see, the workflow is very similar to using a scikit-learn transformer, and visualizers are intended to be integrated along with scikit-learn utilities. Arguments that change how the visualization is drawn can be passed into the visualizer upon instantiation, similarly to how hyperparameters are included with scikit-learn models.
 
 The ``poof()`` method finalizes the drawing (adding titles, axes labels, etc) and then renders the image on your behalf. If you're in a Jupyter notebook, the image should just appear. If you're in a Python script, a GUI window should open with the visualization in interactive form. However, you can also save the image to disk by passing in a file path as follows:
 
@@ -63,11 +63,11 @@ The ``poof()`` method finalizes the drawing (adding titles, axes labels, etc) an
 
     visualizer.poof(outpath="pcoords.png")
 
-The extension of the filename will determine how the image is rendered, in addition to the .png extension, .pdf is also commonly used.
+The extension of the filename will determine how the image is rendered. In addition to the .png extension, .pdf is also commonly used.
 
-.. NOTE:: Data input to Yellowbrick is identical to that of Scikit-Learn: a dataset, ``X``, which is a two-dimensional matrix of shape ``(n,m)`` where ``n`` is the number of instances (rows) and ``m`` is the number of features (columns). The dataset ``X`` can be a Pandas DataFrame, a Numpy array, or even a Python list of lists. Optionally, a vector ``y``, which represents the target variable (in supervised learning), can also be supplied as input. The target ``y`` must have length ``n`` -- the same number of elements as rows in ``X`` and can be a Pandas Series, Numpy array, or Python list.
+.. NOTE:: Data input to Yellowbrick is identical to that of scikit-learn: a dataset, ``X``, which is a two-dimensional matrix of shape ``(n,m)`` where ``n`` is the number of instances (rows) and ``m`` is the number of features (columns). The dataset ``X`` can be a Pandas DataFrame, a NumPy array, or even a Python list of lists. Optionally, a vector ``y``, which represents the target variable (in supervised learning), can also be supplied as input. The target ``y`` must have length ``n`` -- the same number of elements as rows in ``X`` and can be a Pandas Series, NumPy array, or Python list.
 
-Visualizers can also wrap Scikit-Learn models for evaluation, hyperparameter tuning and algorithm selection. For example, to produce a visual heatmap of a classification report, displaying the precision, recall, F1 score, and support for each class in a classifier, wrap the estimator in a visualizer as follows:
+Visualizers can also wrap scikit-learn models for evaluation, hyperparameter tuning and algorithm selection. For example, to produce a visual heatmap of a classification report, displaying the precision, recall, F1 score, and support for each class in a classifier, wrap the estimator in a visualizer as follows:
 
 .. code-block:: python
 
@@ -85,7 +85,7 @@ Only two additional lines of code are required to add visual evaluation of the c
 
 .. TODO:: Walkthrough visual pipelines and text analysis.
 
-The class-based API is meant to integrate with Scikit-Learn directly, however on occasion there are times when you just need a quick visualization. Yellowbrick supports quick functions for taking advantage of this directly. For example, the two visual diagnostics could have been instead implemented as follows:
+The class-based API is meant to integrate with scikit-learn directly, however on occasion there are times when you just need a quick visualization. Yellowbrick supports quick functions for taking advantage of this directly. For example, the two visual diagnostics could have been instead implemented as follows:
 
 .. code-block:: python
 
@@ -138,7 +138,7 @@ The machine learning workflow is the art of creating *model selection triples*, 
 
 This figure shows us the Pearson correlation between pairs of features such that each cell in the grid represents two features identified in order on the x and y axes and whose color displays the magnitude of the correlation. A Pearson correlation of 1.0 means that there is a strong positive, linear relationship between the pairs of variables and a value of -1.0 indicates a strong negative, linear relationship (a value of zero indicates no relationship). Therefore we are looking for dark red and dark blue boxes to identify further.
 
-In this chart we see that features 7 (temperature) and feature 9 (feelslike) have a strong correlation and also that feature 0 (season) has a strong correlation with feature 1 (month). This seems to make sense; the apparent temperature we feel outside depends on the actual temperature and other airquality factors, and the season of the year is described by the month! To dive in deeper, we can use the `JointPlotVisualizer <http://www.scikit-yb.org/en/latest/api/yellowbrick.features.html#module-yellowbrick.features.jointplot>`_ to inspect those relationships.
+In this chart, we see that the features ``temp`` and ``feelslike`` have a strong correlation and also that the feature ``season`` has a strong correlation with the feature ``month``. This seems to make sense; the apparent temperature we feel outside depends on the actual temperature and other airquality factors, and the season of the year is described by the month! To dive in deeper, we can use the `JointPlotVisualizer <http://www.scikit-yb.org/en/latest/api/yellowbrick.features.html#module-yellowbrick.features.jointplot>`_ to inspect those relationships.
 
 .. code-block:: python
 
@@ -219,6 +219,6 @@ We can now train our final model and visualize it with the ``PredictionError`` v
 
 The prediction error visualizer plots the actual (measured) vs. expected (predicted) values against each other. The dotted black line is the 45 degree line that indicates zero error. Like the residuals plot, this allows us to see where error is occurring and in what magnitude.
 
-In this plot we can see that most of the instance density is less than 200 riders. We may want to try orthogonal matching pursuit or splines to fit a regression that takes into account more regionality. We can also note that that weird topology from the residuals plot seems to be fixed using the Ridge regression, and that there is a bit more balance in our model between large and small values. Potentially the Ridge regularization cured a covariance issue we had between two features. As we move forward in our analysis using other model forms, we can continue to utilize visualizers to quickly compare and see our results.
+In this plot, we can see that most of the instance density is less than 200 riders. We may want to try orthogonal matching pursuit or splines to fit a regression that takes into account more regionality. We can also note that that weird topology from the residuals plot seems to be fixed using the Ridge regression, and that there is a bit more balance in our model between large and small values. Potentially the Ridge regularization cured a covariance issue we had between two features. As we move forward in our analysis using other model forms, we can continue to utilize visualizers to quickly compare and see our results.
 
-Hopefully this workflow gives you an idea of how to integrate Visualizers into machine learning with Scikit-Learn and inspires you to use them in your work and write your own! For additional information on getting started with Yellowbrick, check out the :doc:`tutorial`. After that you can get up to speed on specific visualizers detailed in the :doc:`api/index`.
+Hopefully this workflow gives you an idea of how to integrate Visualizers into machine learning with scikit-learn and inspires you to use them in your work and write your own! For additional information on getting started with Yellowbrick, check out the :doc:`tutorial`. After that you can get up to speed on specific visualizers detailed in the :doc:`api/index`.


### PR DESCRIPTION
#328 issue

This pull request includes my initial edits and updates to the Yellowbrick documentation. The majority of the changes are stylistic and intended to create a uniform style that will help prevent any confusion for new and returning users. 

One of the edits you'll notice most often is that I changed all mentions of `Scikit-Learn` to `scikit-learn` unless it is at the beginning of a sentence. In that case, I've changed it to `Scikit-learn`. These changes will make our documentation consistent with scikit-learn's, which clarifies it's correct name and usage on their [faq](http://scikit-learn.org/stable/faq.html).

Other naming updates I made were to make sure that `Yellowbrick` was capitalized and `matplotlib` was not (unless at the beginning of a sentence, in a section header, or as part of an article or tutorial title).

I also corrected the pip installation instructions, since the abbreviated `-U` flag must be capitalized in order to work. 