### PR TITLE
Remove hard-coded test data I left by accident

### DIFF
--- a/tests/test_classifier/test_class_prediction_error.py
+++ b/tests/test_classifier/test_class_prediction_error.py
@@ -20,7 +20,6 @@ Testing for the ClassPredictionError visualizer
 ##########################################################################
 
 import pytest
-import numpy as np
 import matplotlib.pyplot as plt
 
 from yellowbrick.classifier.class_balance import *
@@ -35,17 +34,6 @@ from tests.base import VisualTestCase
 ##########################################################################
 ## Data
 ##########################################################################
-
-X = np.array(
-    [[2.318, 2.727, 4.260, 7.212, 4.792],
-     [2.315, 2.726, 4.295, 7.140, 4.783],
-     [2.315, 2.724, 4.260, 7.135, 4.779],
-     [2.110, 3.609, 4.330, 7.985, 5.595],
-     [2.110, 3.626, 4.330, 8.203, 5.621],
-     [2.110, 3.620, 4.470, 8.210, 5.612]]
-)
-
-y = np.array([1, 1, 0, 1, 0, 0])
 
 X, y = make_classification(
     n_classes=4, n_informative=3, n_clusters_per_class=1, random_state=42


### PR DESCRIPTION
In previous PR #355 , I switched to using sklearn "make_classification" function
to create test data.  However, I forgot to remove the hard-coded test data that
was being replaced. 👎 

This commit removes the numpy arrays that represent the test data
This commit also removes the numpy import statement