### PR TITLE
Adds listserv to documentation

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -37,6 +37,8 @@ Yellowbrick is developed by data scientists who believe in open source and the p
 
 Yellowbrick is incubated by `District Data Labs`_, an organization that is dedicated to collaboration and open source development. As part of District Data Labs, Yellowbrick was first introduced to the Python Community at `PyCon 2016 <https://youtu.be/c5DaaGZWQqY>`_ in both talks and during the development sprints. The project was then carried on through DDL Research Labs (semester-long sprints where members of the DDL community contribute to various data-related projects).
 
+For a full list of current maintainers and core contributors, please see `MAINTAINERS.md <https://github.com/DistrictDataLabs/yellowbrick/blob/develop/MAINTAINERS.md>`_ in the root of our GitHub repository. Thank you so much to everyone who has `contributed to Yellowbrick <https://github.com/DistrictDataLabs/yellowbrick/graphs/contributors>`_!
+
 License
 -------
 
@@ -105,4 +107,19 @@ We hope that Yellowbrick facilitates machine learning of all kinds and we're par
 
 You can also find DOI (digital object identifiers) for every version of Yellowbrick on `zenodo.org <https://doi.org/10.5281/zenodo.1206239>`_; use the BibTeX on this site to reference specific versions or changes made to the software.
 
-We're also currently working on a scientific paper that describes Yellowbrick in the context of *steering the model selection process*. Stay tuned for a pre-release of this paper on arXiv. 
+We're also currently working on a scientific paper that describes Yellowbrick in the context of *steering the model selection process*. Stay tuned for a pre-release of this paper on arXiv.
+
+Contacting Us
+-------------
+
+The best way to contact the Yellowbrick team is to send us a note on one of the following platforms:
+
+- Send an email via our `mailing list`_.
+- Direct message us on `Twitter`_.
+- Ask a question on `Stack Overflow`_.
+- Report an issue on our `GitHub Repo`_.
+
+.. _`GitHub Repo`: https://github.com/DistrictDataLabs/yellowbrick
+.. _`mailing list`: http://bit.ly/yb-listserv
+.. _`Stack Overflow`: https://stackoverflow.com/questions/tagged/yellowbrick
+.. _`Twitter`: https://twitter.com/scikit_yb

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -9,17 +9,26 @@ Principally, Yellowbrick development is about the addition and creation of *visu
 
 Beyond creating visualizers, there are many ways to contribute:
 
-- Submit a bug report or feature request on `GitHub Issues <https://github.com/DistrictDataLabs/yellowbrick/issues>`_.
-- Contribute an Jupyter notebook to our `examples gallery <https://github.com/DistrictDataLabs/yellowbrick/tree/develop/examples>`_.
-- Assist us with `user testing <http://www.scikit-yb.org/en/latest/evaluation.html>`_.
-- Add to the documentation or help with our website, `scikit-yb.org <http://www.scikit-yb.org>`_
+- Submit a bug report or feature request on `GitHub issues`_.
+- Contribute an Jupyter notebook to our `examples gallery`_.
+- Assist us with :doc:`user testing <evaluation>`.
+- Add to the documentation or help with our website, `scikit-yb.org`_
 - Write unit or integration tests for our project.
-- Answer questions on our issues, mailing list, Stack Overflow, and elsewhere.
+- Answer questions on our `GitHub issues`_, `mailing list`_, `Stack Overflow`_, and `Twitter`_.
 - Translate our documentation into another language.
 - Write a blog post, tweet, or share our project with others.
 - Teach someone how to use Yellowbrick.
 
-As you can see, there are lots of ways to get involved and we would be very happy for you to join us! The only thing we ask is that you abide by the principles of openness, respect, and consideration of others as described in the `Python Software Foundation Code of Conduct <https://www.python.org/psf/codeofconduct/>`_.
+As you can see, there are lots of ways to get involved and we would be very happy for you to join us! The only thing we ask is that you abide by the principles of openness, respect, and consideration of others as described in our :doc:`code_of_conduct`.
+
+.. note:: If you're unsure where to start, perhaps the best place is to drop the maintainers a note via our mailing list: http://bit.ly/yb-listserv.
+
+.. _`examples gallery`: https://github.com/DistrictDataLabs/yellowbrick/tree/develop/examples
+.. _`scikit-yb.org`: http://www.scikit-yb.org
+.. _`GitHub issues`: https://github.com/DistrictDataLabs/yellowbrick/issues
+.. _`mailing list`: http://bit.ly/yb-listserv
+.. _`Stack Overflow`: https://stackoverflow.com/questions/tagged/yellowbrick
+.. _`Twitter`: https://twitter.com/scikit_yb
 
 Getting Started on GitHub
 -------------------------


### PR DESCRIPTION
Updates our documentation to include contact info via GitHub, our Google Groups mailing list, Twitter, and StackOverflow. Also references MAINTAINERS.md and the contributors page on GitHub.

Fixes #260