### PR TITLE
Adds StatsModelsWrapper to contrib.

### DIFF
--- a/docs/api/contrib/index.rst
+++ b/docs/api/contrib/index.rst
@@ -1,23 +1,12 @@
 .. -*- mode: rst -*-
 
-Contrib
-==========================
+Yellowbrick Contrib
+===================
 
-The yellowbrick contrib contains a variety of extra tools and experimental visualizers that are outside of core support or are still in development.
-
-
-Classifiers
-==========================
-
-Experimental and undergoing on-going development classification visualizers
-
-.. code:: python
-
-    # Contrib Imports
-
-    from yellowbrick.contrib.classifier import DecisionBoundariesVisualizer
+The ``yellowbrick.contrib`` package contains a variety of extra tools and experimental visualizers that are outside of core support or are still in development. Here is a listing of the contrib modules currently available:
 
 .. toctree::
    :maxdepth: 2
 
    boundaries
+   statsmodels

--- a/docs/api/contrib/statsmodels.rst
+++ b/docs/api/contrib/statsmodels.rst
@@ -1,0 +1,9 @@
+.. -*- mode: rst -*-
+
+StatsModels Visualizers
+=======================
+
+.. automodule:: yellowbrick.contrib.statsmodels.base
+    :members: StatsModelsWrapper
+    :undoc-members:
+    :show-inheritance:

--- a/tests/test_contrib/test_statsmodels/__init__.py
+++ b/tests/test_contrib/test_statsmodels/__init__.py
@@ -1,0 +1,15 @@
+# tests.test_contrib.test_statsmodels
+# Tests for the statsmodels contrib package
+#
+# Author:  Benjamin Bengfort <benjamin@bengfort.com>
+# Created: Wed Apr 04 13:28:13 2018 -0400
+#
+# ID: __init__.py [] benjamin@bengfort.com $
+
+"""
+Tests for the statsmodels contrib package
+"""
+
+##########################################################################
+## Imports
+##########################################################################

--- a/tests/test_contrib/test_statsmodels/test_base.py
+++ b/tests/test_contrib/test_statsmodels/test_base.py
@@ -1,0 +1,46 @@
+# tests.test_contrib.test_statsmodels.test_base
+# Tests for the statsmodels estimator wrapper.
+#
+# Author:  Ian Ozsvald
+# Created: Wed Jan 10 12:47:00 2018 -0500
+#
+# ID: test_base.py [] benjamin@bengfort.com $
+
+"""
+Tests for the statsmodels estimator wrapper.
+"""
+
+##########################################################################
+## Imports
+##########################################################################
+
+import pytest
+import functools
+import numpy as np
+
+from yellowbrick.contrib.statsmodels import StatsModelsWrapper
+
+try:
+    import statsmodels as sm
+except ImportError:
+    sm = None
+
+
+##########################################################################
+## Test Cases
+##########################################################################
+
+@pytest.mark.skipif(sm is None, reason="test requires statsmodels")
+def test_stats_models_wrapper():
+    """
+    A trivial test of the StatsModelsWrapper
+    """
+    X = np.array([[1], [2], [3]])
+    y = np.array([1.1, 2, 3])
+
+    glm_gaussian = functools.partial(sm.GLM, family=sm.families.Gaussian())
+    sm_est = StatsModelsWrapper(glm_gaussian)
+
+    assert sm_est.fit(X, y) is sm_est, "fit did not return self"
+    assert sm_est.predict(X).shape == (3,)
+    assert 0.0 <= sm_est.score(X, y) <= 1.0

--- a/yellowbrick/contrib/statsmodels/__init__.py
+++ b/yellowbrick/contrib/statsmodels/__init__.py
@@ -1,0 +1,17 @@
+# yellowbrick.contrib.statsmodels
+# Implements wrappers around hte statsmodels library to use Yellowbrick with.
+#
+# Author:  Benjamin Bengfort <benjamin@bengfort.com>
+# Created: Wed Apr 04 13:13:24 2018 -0400
+#
+# ID: __init__.py [] benjamin@bengfort.com $
+
+"""
+Implements wrappers around hte statsmodels library to use Yellowbrick with.
+"""
+
+##########################################################################
+## Imports
+##########################################################################
+
+from .base import StatsModelsWrapper

--- a/yellowbrick/contrib/statsmodels/base.py
+++ b/yellowbrick/contrib/statsmodels/base.py
@@ -1,0 +1,84 @@
+# yellowbrick.contrib.statsmodels.base
+# A basic wrapper for statsmodels that emulates a scikit-learn estimator.
+#
+# Author:  Ian Ozsvald
+# Created: Wed Jan 10 12:47:00 2018 -0500
+#
+# ID: base.py [] benjamin@bengfort.com $
+
+"""
+A basic wrapper for statsmodels that emulates a scikit-learn estimator.
+"""
+
+##########################################################################
+## Imports
+##########################################################################
+
+from sklearn.metrics import r2_score
+from sklearn.base import BaseEstimator
+
+
+##########################################################################
+## statsmodels Estimator
+##########################################################################
+
+class StatsModelsWrapper(BaseEstimator):
+    """
+    Wrap a statsmodels GLM as a sklearn (fake) BaseEstimator for YellowBrick.
+
+    Examples
+    --------
+    First import the external libraries and helper utilities:
+
+    >>> import statsmodels as sm
+    >>> from functools import partial
+
+    Instantiate a partial with the statsmodels API:
+
+    >>> glm_gaussian_partial = partial(sm.GLM, family=sm.families.Gaussian())
+    >>> sm_est = StatsModelsWrapper(glm_gaussian_partial)
+
+    Create a Yellowbrick visualizer to visualize prediction error:
+
+    >>> visualizer = PredictionError(sm_est)
+    >>> visualizer.fit(X_train, y_train)
+    >>> visualizer.score(X_test, y_test)
+
+    For statsmodels usage, calling .summary() etc:
+
+    >>> gaussian_model = glm_gaussian_partial(y_train, X_train)
+
+    Note
+    ----
+    .. note:: This wrapper is trivial, options and extra things like weights
+        are not currently handled.
+    """
+    def __init__(self, glm_partial, stated_estimator_type="regressor",
+                 scorer=r2_score):
+
+        # YellowBrick checks the attribute to see if it is a
+        # regressor/clusterer/classifier
+        self._estimator_type = stated_estimator_type
+
+        # assume user passes in a partial which we can instantiate later
+        self.glm_partial = glm_partial
+
+        # needs a default scoring function, regression uses r^2 in sklearn
+        self.scorer = scorer
+
+    def fit(self, X, y):
+        """
+        Pretend to be a sklearn estimator, fit is called on creation
+        """
+
+        # note that GLM takes endog (y) and then exog (X):
+        # this is the reverse of sklearn's methods
+        self.glm_model = self.glm_partial(y, X)
+        self.glm_results = self.glm_model.fit()
+        return self
+
+    def predict(self, X):
+        return self.glm_results.predict(X)
+
+    def score(self, X, y):
+        return self.scorer(y, self.predict(X))


### PR DESCRIPTION
This PR places the lightweight wrapper suggested by @ianozsvald in `yellowbrick.contrib` to implement Yellowbrick visualizers with StatsModels. It also adds a documentation stub and test stubs, though it could certainly benefit from more from `statsmodels` users. 

Resolves #306: A new issue should be created to update and document this wrapper if required.