### PR TITLE
Add apt-get update command to the travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - '3.6'
 
 before_install:
+  - sudo apt-get update
   - sudo apt-get build-dep python-scipy
 
 install:


### PR DESCRIPTION
Looks like this failing job is suggesting running the following command before installing dependencies:

https://travis-ci.org/DistrictDataLabs/yellowbrick/jobs/378804441

`sudo apt-get update`

Let's open this PR to see if it fixes it.

@DistrictDataLabs/team-oz-maintainers
