### PR TITLE
added colorization to negative bar chart

### DIFF
--- a/yellowbrick/features/importances.py
+++ b/yellowbrick/features/importances.py
@@ -86,7 +86,7 @@ class FeatureImportances(ModelVisualizer):
     >>> visualizer.poof()
     """
 
-    def __init__(self, model, ax=None, labels=None, relative=True,
+    def __init__(self, model, ax=None, labels=None, relative=True, color_neg='b', color_pos='g',
                  absolute=False, xlabel=None, **kwargs):
         super(FeatureImportances, self).__init__(model, ax, **kwargs)
 
@@ -95,6 +95,9 @@ class FeatureImportances(ModelVisualizer):
             labels=labels, relative=relative, absolute=absolute,
             xlabel=xlabel,
         )
+        self.color_neg = color_neg
+        self.color_pos =color_pos
+
 
     def fit(self, X, y=None, **kwargs):
         """
@@ -168,9 +171,12 @@ class FeatureImportances(ModelVisualizer):
         pos = np.arange(self.features_.shape[0]) + 0.5
 
         # Plot the bar chart
-        colors = np.array(['b' if v > 0 else 'g' for v in self.feature_importances_])
+        #raise Exception(self.feature_importances_)
+        # Plot the bar chart
+
+
+        colors = np.array([self.color_pos if v > 0 else self.color_neg for v in self.feature_importances_])
         self.ax.barh(pos, self.feature_importances_, color=colors, align='center')
-        #self.ax.barh(pos, self.feature_importances_, align='center')
 
         # Set the labels for the bars
         self.ax.set_yticks(pos)

--- a/yellowbrick/features/importances.py
+++ b/yellowbrick/features/importances.py
@@ -168,7 +168,9 @@ class FeatureImportances(ModelVisualizer):
         pos = np.arange(self.features_.shape[0]) + 0.5
 
         # Plot the bar chart
-        self.ax.barh(pos, self.feature_importances_, align='center')
+        colors = np.array(['b' if v > 0 else 'g' for v in self.feature_importances_])
+        self.ax.barh(pos, self.feature_importances_, color=colors, align='center')
+        #self.ax.barh(pos, self.feature_importances_, align='center')
 
         # Set the labels for the bars
         self.ax.set_yticks(pos)


### PR DESCRIPTION
Fixes #322 

[Description]
addressed just the first item
Changes proposed in this pull request:

-the previous bar graph was commented out. 2 additional lines were added: one for color, the second for graphing the color if the item is negative.
-
-

@DistrictDataLabs/team-oz-maintainers
