### PR TITLE
Fix: If applied it corrects error in documentation for Classification Report Visualizer

### DIFF
--- a/docs/api/classifier/classification_report.rst
+++ b/docs/api/classifier/classification_report.rst
@@ -32,7 +32,7 @@ The classification report visualizer displays the precision, recall, F1, and sup
 
     # Instantiate the classification model and visualizer
     bayes = GaussianNB()
-    visualizer = ClassificationReport(bayes, classes=classes)
+    visualizer = ClassificationReport(bayes, classes=classes, support=True)
 
     visualizer.fit(X_train, y_train)  # Fit the visualizer and the model
     visualizer.score(X_test, y_test)  # Evaluate the model on the test data


### PR DESCRIPTION
The documentation was not updated to show that Classification Report now has a support parameter.  The example code was missing the support parameter, however the CR displayed a 'support' score.  I corrected the code by adding ```support=True```