### PR TITLE
Fixes #433 - Correct spelling of "Principal" in PCA rst

### DIFF
--- a/docs/api/features/pca.rst
+++ b/docs/api/features/pca.rst
@@ -3,7 +3,7 @@
 PCA Projection
 ==============
 
-The PCA Decomposition visualizer utilizes principle component analysis to decompose high dimensional data into two or three dimensions so that each instance can be plotted in a scatter plot. The use of PCA means that the projected dataset can be analyzed along axes of principle variation and can be interpreted to determine if spherical distance metrics can be utilized.
+The PCA Decomposition visualizer utilizes principal component analysis to decompose high dimensional data into two or three dimensions so that each instance can be plotted in a scatter plot. The use of PCA means that the projected dataset can be analyzed along axes of principal variation and can be interpreted to determine if spherical distance metrics can be utilized.
 
 .. code:: python
 


### PR DESCRIPTION
In the rst file of principal component analysis, which is located
in docs/api/features/pca.rst, "principal" was misspelled as "principle"

This was corrected because we want to keep our documentation in
tip-top shape.  Our documentation sets us apart from other projects