### PR TITLE
Link Dispersion Plot from index and README

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -68,7 +68,8 @@ Text Visualization
 ~~~~~~~~~~~~~~~~~~
 
 - **Term Frequency**: visualize the frequency distribution of terms in the corpus
-- **t-SNE Corpus Visualization**: use stochastic neighbor embedding to project documents.
+- **t-SNE Corpus Visualization**: use stochastic neighbor embedding to project documents
+- **Dispersion Plot**: visualize how key terms are dispersed throughout a corpus
 
 ... and more! Visualizers are being added all the time; be sure to check the examples_ (or even the develop_ branch) and feel free to contribute your ideas for new Visualizers!
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Visualizers are estimators (objects that learn from data) whose primary objectiv
 
 - **Term Frequency**: visualize the frequency distribution of terms in the corpus
 - **t-SNE Corpus Visualization**: use stochastic neighbor embedding to project documents.
+- **Dispersion Plot**: visualize how key terms are dispersed throughout a corpus
 
 And more! Visualizers are being added all the time, so be sure to check the examples (or even the develop branch) and feel free to contribute your ideas for Visualizers!
 

--- a/docs/api/text/dispersion.rst
+++ b/docs/api/text/dispersion.rst
@@ -3,22 +3,22 @@
 Dispersion Plot
 ===============
 
-A word's importance can be weighed by its dispersion in a corpus.  Lexical dispersion is a measure of a word's homogeneity across the parts of a corpus.  This plot notes the occurences of a word and how many words from the beginning of the corpus it appears.
+A word's importance can be weighed by its dispersion in a corpus.  Lexical dispersion is a measure of a word's homogeneity across the parts of a corpus.  This plot notes the occurrences of a word and how many words from the beginning of the corpus it appears.
 
 .. code:: python
-    
+
     from yellowbrick.text import DispersionPlot
 
 After importing the visualizer, we can :doc:`load the corpus <corpus>`
 
-.. code:: python 
+.. code:: python
 
     # Load the text data
     corpus = load_corpus("hobbies")
-    
+
     # create a list of words from the corpus text
     text = [word for doc in corpus.data for word in doc.split()]
-    
+
     # Choose words whose occurence in the text will be plotted
     target_words = ['Game', 'player', 'score', 'oil', 'Man']
 
@@ -26,7 +26,7 @@ After importing the visualizer, we can :doc:`load the corpus <corpus>`
     visualizer = DispersionPlot(target_words)
     visualizer.fit(text)
     visualizer.poof()
-   
+
 
 .. image:: images/dispersion_docs.png
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,7 +63,8 @@ Text Visualization
 ~~~~~~~~~~~~~~~~~~
 
 - :doc:`Term Frequency <api/text/freqdist>`: visualize the frequency distribution of terms in the corpus
-- :doc:`api/text/tsne`: use stochastic neighbor embedding to project documents.
+- :doc:`api/text/tsne`: use stochastic neighbor embedding to project documents
+- :doc:`api/text/dispersion`: visualize how key terms are dispersed throughout a corpus
 
 ... and more! Visualizers are being added all the time; be sure to check the examples (or even the `develop branch <https://github.com/DistrictDataLabs/yellowbrick/tree/develop>`_) and feel free to contribute your ideas for new Visualizers!
 


### PR DESCRIPTION
Added links to the dispersion plot from the main documentation home
page, the README, and DESCRIPTION.