### PR TITLE
Fixes Manifold fit_transform bug.

### DIFF
--- a/yellowbrick/features/manifold.py
+++ b/yellowbrick/features/manifold.py
@@ -264,6 +264,14 @@ class Manifold(FeatureVisualizer):
     def fit(self, X, y=None):
         """
         Fits the manifold on X and transforms the data to plot it on the axes.
+        See fit_transform() for more details.
+        """
+        self.fit_transform(X, y)
+        return self
+
+    def fit_transform(self, X, y=None):
+        """
+        Fits the manifold on X and transforms the data to plot it on the axes.
         The optional y specified can be used to declare discrete colors. If
         the target is set to 'auto', this method also determines the target
         type, and therefore what colors will be used.
@@ -311,7 +319,7 @@ class Manifold(FeatureVisualizer):
         self.fit_time_ = time.time() - start
 
         self.draw(Xp, y)
-        return self
+        return Xp
 
     def transform(self, X):
         """
@@ -327,7 +335,10 @@ class Manifold(FeatureVisualizer):
         Xprime : array-like of shape (n, 2)
             Returns the 2-dimensional embedding of the instances.
         """
-        return self.manifold.transform(X)
+        try:
+            return self.manifold.transform(X)
+        except AttributeError as e:
+            raise AttributeError(str(e) + " try using fit_transform instead.")
 
     def draw(self, X, y=None):
         """


### PR DESCRIPTION
Some manifolds do not provide a `transform()` method since the data transformation process cannot be decoupled from the `fit()` process. In this case, the user is required to call `fit_transform()` to get the transformed data. Unfortunately, the `Manifold` visualizer implemented the `TransformerMixn` and `fit()` and `transform()` methods, so when calling the default `fit_transform()` method an exception was raised.

Because the `fit()` method already called `fit_transform()` - the fix was simple. `Manifold` now overrides `fit_transform()` to do the work that `fit()` used to do, and `fit()` simply calls `fit_transform()`. In addition, I've captured `AttributeError` exceptions in `transform()` and reraised them with a message that indicates the user should use `fit_transform()` instead.

Tests have been added to ensure `fit()` calls `fit_transform()`, that `fit_transform()` works as expected, and that `transform()` raises the correct exception.

Fixes #504