### PR TITLE
Fixes #523, Adds probability density function to ResidualsPlot's histogram

### DIFF
--- a/yellowbrick/regressor/residuals.py
+++ b/yellowbrick/regressor/residuals.py
@@ -334,9 +334,11 @@ class ResidualsPlot(RegressionScoreVisualizer):
         The axes to plot the figure on. If None is passed in the current axes
         will be used (or generated if required).
 
-    hist : bool, default: True
+    hist : {True, False, None, 'density', 'frequency'}, default: True
         Draw a histogram showing the distribution of the residuals on the
         right side of the figure. Requires Matplotlib >= 2.0.2.
+        If set to 'density', the probability density function will be plotted.
+        If set to True or 'frequency' then the frequency will be plotted.  
 
     train_color : color, default: 'b'
         Residuals for training data are ploted with this color but also
@@ -385,9 +387,15 @@ class ResidualsPlot(RegressionScoreVisualizer):
             'test_point': test_color,
             'line': line_color,
         }
-
+        
         self.hist = hist
-        if self.hist:
+        if self.hist not in {True, 'density', 'frequency', None, False}:
+                raise YellowbrickValueError(
+                    "'{}' is an invalid argument for hist, use None, True, " \
+                    "False, 'density', or 'frequency'".format(hist)
+                )
+
+        if self.hist in {True, 'density', 'frequency'}:
             self.hax # If hist is True, test the version availability
 
     @memoized
@@ -503,9 +511,11 @@ class ResidualsPlot(RegressionScoreVisualizer):
         # Draw the residuals scatter plot
         self.ax.scatter(y_pred, residuals, c=color, alpha=alpha, label=label)
 
-        # Add residuals histogram histogram
-        if self.hist:
+        # Add residuals histogram
+        if self.hist in {True, 'frequency'}:
             self.hax.hist(residuals, bins=50, orientation="horizontal")
+        elif self.hist == 'density':
+            self.hax.hist(residuals, bins=50, orientation="horizontal", density=True)
 
         # Ensure the current axes is always the main residuals axes
         plt.sca(self.ax)
@@ -575,9 +585,11 @@ def residuals_plot(model,
         The axes to plot the figure on. If None is passed in the current axes
         will be used (or generated if required).
 
-    hist : bool, default: True
+    hist : {True, False, None, 'density', 'frequency'}, default: True
         Draw a histogram showing the distribution of the residuals on the
         right side of the figure. Requires Matplotlib >= 2.0.2.
+        If set to 'density', the probability density function will be plotted.
+        If set to True or 'frequency' then the frequency will be plotted.  
 
     test_size : float, int default: 0.25
         If float, should be between 0.0 and 1.0 and represent the proportion


### PR DESCRIPTION
Currently, the ResidualsPlot visualizer's histogram only displays the
frequency distribution when the ``hist`` argument is set to True.

This commit adds the option for probability density function(PDF).
This change allows for direct specification of density or frequency via
the ``hist`` argument.  By default, 'frequency' will be plotted.

``` python
from sklearn.linear_model import LinearRegression
from sklearn.datasets import make_regression
from sklearn.model_selection import train_test_split as tts
from yellowbrick.regressor import ResidualsPlot

X, y = make_regression(
    n_samples=500, n_features=22, n_informative=8, random_state=42,
    noise=0.2, bias=0.2,
)

X_train, X_test, y_train, y_test = tts(
    X, y, test_size=0.2, random_state=11
)

visualizer = ResidualsPlot(LinearRegression(), hist='density')
visualizer.fit(X_train, y_train)
residuals = visualizer.score(X_test, y_test)
visualizer.poof()
```
![image](https://user-images.githubusercontent.com/1000117/43474719-a5fd2678-94c1-11e8-898f-5682ce92611c.png)

``` python
visualizer = ResidualsPlot(LinearRegression(), hist='frequency')
visualizer.fit(X_train, y_train)
residuals = visualizer.score(X_test, y_test)
visualizer.poof()
```
![image](https://user-images.githubusercontent.com/1000117/43474818-e4b591ca-94c1-11e8-9742-22606c3d3ab3.png)
