### PR TITLE
feat: Add tests to Rank2D

### DIFF
--- a/tests/test_features/test_rankd.py
+++ b/tests/test_features/test_rankd.py
@@ -135,4 +135,10 @@ class TestRank2D(VisualTestCase, DatasetMixin):
 
         tol = 10 if six.PY2 else 0.1
         self.assert_images_similar(visualizer, tol=tol)
+    
+    def test_pearson(self):
+    
+    def test_covariance(self):
+    
+    def test_spearman(self):
 #

--- a/yellowbrick/features/rankd.py
+++ b/yellowbrick/features/rankd.py
@@ -448,7 +448,7 @@ class Rank2D(RankDBase):
     ranking_methods = {
         'pearson': lambda X: np.corrcoef(X.transpose()),
         'covariance': lambda X: np.cov(X.transpose()),
-        'spearman': lambda X: spearmanr(X)[0],
+        'spearman': lambda X: spearmanr(X,axis=0)[0],
     }
 
     def __init__(self, ax=None, algorithm='pearson', features=None,


### PR DESCRIPTION
This PR would add tests for testing
- [ ] Pearson,
- [ ] Covariance and
- [ ] Spearman rank-order correlation

in Rank2D.

Note : I've just opened this PR ( as mentioned in CONTRIBUTING.md ). Work in progress.

Ref: Github issue #628