### PR TITLE
Autolayout to rcParams to address #613

### DIFF
--- a/yellowbrick/style/rcmod.py
+++ b/yellowbrick/style/rcmod.py
@@ -198,6 +198,7 @@ def _axes_style(style=None, rc=None):
         # Common parameters
         style_dict = {
             "figure.facecolor": "white",
+            "figure.autolayout" : True,
             "text.color": dark_gray,
             "axes.labelcolor": dark_gray,
             "legend.frameon": False,


### PR DESCRIPTION
I added a line to rcmod.py to do auto layout formatting. It worked on my Mac laptop in and out of the jupyter notebook using @rebeccabilbro's example script.