### PR TITLE
Update the text of documentation code examples

### DIFF
--- a/docs/api/classifier/classification_report.rst
+++ b/docs/api/classifier/classification_report.rst
@@ -18,9 +18,9 @@ The classification report visualizer displays the precision, recall, F1, and sup
     ]
     classes = ["unoccupied", "occupied"]
 
-    # Extract the numpy arrays from the data frame
-    X = data[features].as_matrix()
-    y = data.occupancy.as_matrix()
+    # Extract the instances and target
+    X = data[features]
+    y = data.occupancy
 
     # Create the train and test data
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)

--- a/docs/api/classifier/rocauc.rst
+++ b/docs/api/classifier/rocauc.rst
@@ -20,9 +20,9 @@ This leads to another metric, area under the curve (AUC), which is a computation
     features = ["temperature", "relative humidity", "light", "C02", "humidity"]
     classes = ["unoccupied", "occupied"]
 
-    # Extract the numpy arrays from the data frame
-    X = data[features].values
-    y = data.occupancy.values
+    # Extract the instances and target
+    X = data[features]
+    y = data.occupancy
 
     # Create the train and test data
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
@@ -68,7 +68,7 @@ ROC curves are typically used in binary classification, and in fact the Scikit-L
     # Encode the non-numeric columns
     game.replace({'loss':-1, 'draw':0, 'win':1, 'x':2, 'o':3, 'b':4}, inplace=True)
 
-    # Extract the numpy arrays from the data frame
+    # Extract the instances and target
     X = game.iloc[:, game.columns != 'outcome']
     y = game['outcome']
 

--- a/docs/api/features/manifold.rst
+++ b/docs/api/features/manifold.rst
@@ -69,7 +69,7 @@ this by assigning a color to each label and showing the labels in a legend.
         "temperature", "relative humidity", "light", "C02", "humidity"
     ]
 
-    # Extract the data from the data frame.
+    # Extract the instances and target
     X = data[features]
     y = data.occupancy
 
@@ -106,7 +106,18 @@ the ``f_classif`` score to find the 3 best features in our occupancy dataset.
         ("viz", Manifold(manifold='isomap', target='discrete')),
     ])
 
-    X, y = load_occupancy_data()
+    # Load the classification dataset
+    data = load_data("occupancy")
+
+    # Specify the features of interest
+    features = [
+        "temperature", "relative humidity", "light", "CO2", "humidity"
+    ]
+
+    # Extract the instances and target
+    X = data[features]
+    y = data.occupancy
+
     model.fit(X, y)
     model.named_steps['viz'].poof()
 

--- a/docs/api/features/pcoords.rst
+++ b/docs/api/features/pcoords.rst
@@ -18,6 +18,7 @@ Data scientists use this method to detect clusters of instances that have simila
     ]
     classes = ["unoccupied", "occupied"]
 
+    # Extract the instances and target
     X = data[features]
     y = data.occupancy
 

--- a/docs/api/features/radviz.rst
+++ b/docs/api/features/radviz.rst
@@ -31,9 +31,9 @@ A good starting place is the `scikit-learn Imputer. <http://scikit-learn.org/sta
     features = ["temperature", "relative humidity", "light", "C02", "humidity"]
     classes = ["unoccupied", "occupied"]
 
-    # Extract the numpy arrays from the data frame
-    X = data[features].as_matrix()
-    y = data.occupancy.as_matrix()
+    # Extract the instances and target
+    X = data[features]
+    y = data.occupancy
 
 .. code:: python
 

--- a/docs/api/features/rankd.rst
+++ b/docs/api/features/rankd.rst
@@ -20,9 +20,9 @@ In this example, we'll use the credit default data set from the UCI Machine Lear
             'jul_pay', 'aug_pay', 'sep_pay',
         ]
 
-    # Extract the numpy arrays from the data frame
-    X = data[features].as_matrix()
-    y = data.default.as_matrix()
+    # Extract the instances and target
+    X = data[features]
+    y = data.default
 
 Rank 1D
 -------

--- a/docs/api/model_selection/cross_validation.rst
+++ b/docs/api/model_selection/cross_validation.rst
@@ -30,13 +30,15 @@ In the following example we show how to visualize cross-validated scores for a c
     from yellowbrick.model_selection import CVScores
 
 
-    room = load_data("occupancy")
+    # Load the classification data set
+    data = load_data("occupancy")
 
+    # Specify the features of interest
     features = ["temperature", "relative humidity", "light", "C02", "humidity"]
 
-    # Extract the numpy arrays from the data frame
-    X = room[features].values
-    y = room.occupancy.values
+    # Extract the instances and target
+    X = data[features]
+    y = data.occupancy
 
     # Create a new figure and axes
     _, ax = plt.subplots()
@@ -70,13 +72,16 @@ In this next example we show how to visualize cross-validated scores for a regre
     from sklearn.model_selection import KFold
 
 
-    energy = load_data("energy")
+    # Load the regression data set
+    data = load_data("energy")
 
+    # Specify the features of interest and the target
     targets = ["heating load", "cooling load"]
-    features = [col for col in energy.columns if col not in targets]
+    features = [col for col in data.columns if col not in targets]
 
-    X = energy[features]
-    y = energy[targets[1]]
+    # Extract the instances and target
+    X = data[features]
+    y = data[targets[1]]
 
     # Create a new figure and axes
     _, ax = plt.subplots()

--- a/docs/api/model_selection/learning_curve.rst
+++ b/docs/api/model_selection/learning_curve.rst
@@ -75,6 +75,7 @@ Building a learning curve for a regression is straight forward and very similar.
     targets = ["heating load", "cooling load"]
     features = [col for col in data.columns if col not in targets]
 
+    # Extract the instances and target
     X = data[features]
     y = data[targets[0]]
 

--- a/docs/api/model_selection/validation_curve.rst
+++ b/docs/api/model_selection/validation_curve.rst
@@ -23,6 +23,7 @@ In our first example, we'll explore using the ``ValidationCurve`` visualizer wit
     targets = ["heating load", "cooling load"]
     features = [col for col in data.columns if col not in targets]
 
+    # Extract the instances and target
     X = data[features]
     y = data[targets[0]]
 

--- a/docs/api/regressor/alphas.rst
+++ b/docs/api/regressor/alphas.rst
@@ -9,16 +9,18 @@ The AlphaSelection Visualizer demonstrates how different values of alpha influen
 
 .. code:: python
 
-    # Load the data
+    # Load the regression data set
     df = load_data('concrete')
-    feature_names = [
+
+    # Specify the features of interest and the target
+    features = [
         'cement', 'slag', 'ash', 'water', 'splast', 'coarse', 'fine', 'age'
     ]
-    target_name = 'strength'
+    target = 'strength'
 
-    # Get the X and y data from the DataFrame
-    X = df[feature_names].as_matrix()
-    y = df[target_name].as_matrix()
+    # Extract the instances and target
+    X = df[features]
+    y = df[target]
 
 .. code:: python
 

--- a/docs/api/regressor/peplot.rst
+++ b/docs/api/regressor/peplot.rst
@@ -9,14 +9,16 @@ A prediction error plot shows the actual targets from the dataset against the pr
 
     from sklearn.model_selection import train_test_split
 
-    # Load the data
-    df = load_data('concrete')
-    feature_names = ['cement', 'slag', 'ash', 'water', 'splast', 'coarse', 'fine', 'age']
-    target_name = 'strength'
+    # Load the regression data set
+    data = load_data('concrete')
 
-    # Get the X and y data from the DataFrame
-    X = df[feature_names].as_matrix()
-    y = df[target_name].as_matrix()
+    # Specify the features of interest and the target
+    features = ['cement', 'slag', 'ash', 'water', 'splast', 'coarse', 'fine', 'age']
+    target = 'strength'
+
+    # Extract the instances and target
+    X = data[features]
+    y = data[target]
 
     # Create the train and test data
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)

--- a/docs/api/target/class_balance.rst
+++ b/docs/api/target/class_balance.rst
@@ -14,6 +14,8 @@ There are several techniques for dealing with class imbalance such as stratified
 
     # Load the classification data set
     data = load_game()
+
+    # Specify the target
     y = data["outcome"]
 
     visualizer = ClassBalance(labels=["draw", "loss", "win"])
@@ -33,11 +35,17 @@ The ``ClassBalance`` visualizer has a "compare" mode, where the train and test d
 
 .. code:: python
 
-    data = load_occupancy
+    from sklearn.model_selection import train_test_split
+    from yellowbrick.model_selection import ClassBalance
 
+    # Load the classification data set
+    data = load_data('occupancy')
+
+    # Specify the features of interest and the target
     features = ["temperature", "relative_humidity", "light", "C02", "humidity"]
-    classes = ['unoccupied', 'occupied']
+    classes = ["unoccupied", "occupied"]
 
+    # Extract the instances and target
     X = data[features]
     y = data["occupancy"]
 

--- a/docs/api/text/dispersion.rst
+++ b/docs/api/text/dispersion.rst
@@ -16,7 +16,7 @@ After importing the visualizer, we can :doc:`load the corpus <corpus>`
     # Load the text data
     corpus = load_corpus("hobbies")
 
-    # create a list of words from the corpus text
+    # Create a list of words from the corpus text
     text = [word for doc in corpus.data for word in doc.split()]
 
     # Choose words whose occurence in the text will be plotted


### PR DESCRIPTION
I removed the deprecated `as_matrix` method from the code examples in Yellowbrick's documentation.

I also added comments or made small text changes to the comments in the code examples to help give our documentation a more uniform appearance. For example:

```
# Specify the features of interest and target
features = ["feature1", "feature2"]
target = "target variable"

# Extract the instances and target
X = data[features]
y = data[target]
```
And in the cases where I made small changes, I'll comments to files to help explain. Just let me know if you have any questions!