### PR TITLE
Reinstate mpl 3

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # Library Dependencies
-matplotlib>=1.5.1
+matplotlib>=1.5.1,!=3.0.0
 scipy>=0.19
 scikit-learn>=0.19
 numpy>=1.13.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # Library Dependencies
-matplotlib>=1.5.1,<3.0
+matplotlib>=1.5.1
 scipy>=0.19
 scikit-learn>=0.19
 numpy>=1.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ## Dependencies
-matplotlib>=1.5.1
+matplotlib>=1.5.1,!=3.0.0
 scipy>=1.0.0
 scikit-learn>=0.20
 numpy>=1.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ## Dependencies
-matplotlib>=1.5.1,<3.0
+matplotlib>=1.5.1
 scipy>=1.0.0
 scikit-learn>=0.20
 numpy>=1.13.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 # Library Dependencies
-matplotlib>=1.5.1
+matplotlib>=1.5.1,!=3.0.0
 scipy>=0.19
 scikit-learn>=0.19
 numpy>=1.13.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 # Library Dependencies
-matplotlib>=1.5.1,<3.0
+matplotlib>=1.5.1
 scipy>=0.19
 scikit-learn>=0.19
 numpy>=1.13.0


### PR DESCRIPTION
matplotlib 3.0.0 had introduced a bug which caused some issues with some of the visualizations. matplotlib 3.0.1 and above corrects the issue. This PR reinstates mpl 3.x support.

Specifically, it reverts the matplotlib version restriction introduced by: https://github.com/DistrictDataLabs/yellowbrick/pull/618

It replaces it with !=3.0.0. That way it'll skip the problematic version 3.0.0 but allow later 3.0.x versions.

Ran the tests using make test, no issues, but I don't know if there are extra tests to run.