### PR TITLE
Fix errors related to release of pytest 4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,11 @@ cycler>=0.10.0
 #umap-learn>=0.3
 
 ## Testing Requirements (pip install -r tests/requirements.txt)
-#pytest>=3.4.1
-#pytest-cov>=2.5.1
-#pytest-flakes>=2.0.0
+#pytest>=4.2.0
+#pytest-cov>=2.6.1
+#pytest-flakes>=4.0.0
 #pytest-spec>=1.1.0
-#coverage>=4.4.1
+#coverage>=4.5.2
 #requests>=2.18.3
 #six==1.11.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,8 @@ tests = True
 test=pytest
 
 [tool:pytest]
-addopts = --verbose --cov=yellowbrick --flakes --spec
+# TODO: add --spec and --verbose back to addopts
+addopts = --cov=yellowbrick --flakes
 python_files = tests/*
 flakes-ignore =
     __init__.py UnusedImport

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,7 @@ def pytest_itemcollected(item):
     suffix = docline(node) or node.__name__
 
     # Add parametrize or test generation id to distinguish it in output
+    # TODO: this is broken with pytest 4.2 (no attribute _genid)
     if hasattr(item, "_genid") and item._genid:
         suffix += " ({})".format(item._genid)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,17 @@ from pytest_flakes import FlakesItem
 ## PyTest Hooks
 ##########################################################################
 
+def docline(obj):
+    """
+    Returns the first line of the object's docstring or None if
+    there is no __doc__ on the object.
+    """
+    if not obj.__doc__:
+        return None
+    lines = list(filter(None, obj.__doc__.split("\n")))
+    return lines[0].strip()
+
+
 def pytest_itemcollected(item):
     """
     A reporting hook that is called when a test item is collected.
@@ -49,11 +60,11 @@ def pytest_itemcollected(item):
     # or class name, and the docstring of the test case, then set the nodeid
     # so that pytest-spec will correctly parse the information.
     path = os.path.relpath(str(item.fspath))
-    prefix = parent.__doc__ or getattr(parent, '__name__', parent.__class__.__name__)
-    suffix = node.__doc__.strip() if node.__doc__ else node.__name__
+    prefix = docline(parent) or getattr(parent, '__name__', parent.__class__.__name__)
+    suffix = docline(node) or node.__name__
 
     # Add parametrize or test generation id to distinguish it in output
-    if item._genid:
+    if hasattr(item, "_genid") and item._genid:
         suffix += " ({})".format(item._genid)
 
     if prefix or suffix:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,7 +9,7 @@ cycler>=0.10.0
 pytest>=4.2.0
 pytest-cov>=2.6.1
 pytest-flakes>=4.0.0
-pytest-spec>=1.1.0
+#pytest-spec>=1.1.0
 coverage>=4.5.2
 requests>=2.18.3
 six==1.11.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,16 +1,16 @@
 # Library Dependencies
 matplotlib>=1.5.1,!=3.0.0
-scipy>=0.19
-scikit-learn>=0.19
+scipy>=1.0.0
+scikit-learn>=0.20
 numpy>=1.13.0
 cycler>=0.10.0
 
 # Testing Requirements
-pytest>=3.4.1
-pytest-cov>=2.5.1
-pytest-flakes>=2.0.0
+pytest>=4.2.0
+pytest-cov>=2.6.1
+pytest-flakes>=4.0.0
 pytest-spec>=1.1.0
-coverage>=4.4.1
+coverage>=4.5.2
 requests>=2.18.3
 six==1.11.0
 


### PR DESCRIPTION
The release of pytest 4.2 broke some of our custom pytest-spec related code (e.g. how the test report is printed). This PR attempts to solve some of the issues, but I've also [opened an issue](https://github.com/pchomik/pytest-spec/issues/21) with pytest-spec to see if we can resolve some of the warnings and add the parametrize ids back into the code base.

- [x] Fix the errors and get tests running again 
- [x] Check if CI now passes 
- [ ] Repair the parametrize custom ids 
- [ ] Fix the (**1146**!!!) warnings now issued by pytest