### PR TITLE
Hotfix v0.9.1: matplotlib 3 support

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # Library Dependencies
-matplotlib>=1.5.1,<3.0
+matplotlib>=1.5.1,!=3.0.0
 scipy>=0.19
 scikit-learn>=0.19
 numpy>=1.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ## Dependencies
-matplotlib>=1.5.1,<3.0
+matplotlib>=1.5.1,!=3.0.0
 scipy>=1.0.0
 scikit-learn>=0.20
 numpy>=1.13.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,12 +1,12 @@
 # Library Dependencies
-matplotlib>=1.5.1,<3.0
+matplotlib>=1.5.1,!=3.0.0
 scipy>=0.19
 scikit-learn>=0.19
 numpy>=1.13.0
 cycler>=0.10.0
 
 # Testing Requirements
-pytest>=3.4.1
+pytest>=3.4.1,<4.2.0
 pytest-cov>=2.5.1
 pytest-flakes>=2.0.0
 pytest-spec>=1.1.0

--- a/tests/test_classifier/test_confusion_matrix.py
+++ b/tests/test_classifier/test_confusion_matrix.py
@@ -334,6 +334,9 @@ class ConfusionMatrixTests(VisualTestCase, DatasetMixin):
         with pytest.raises(yb.exceptions.YellowbrickError, match=message):
             ConfusionMatrix(model)
 
+    @pytest.mark.xfail(
+        sys.platform == 'win32', reason="Changing the dtype to a subarray type is only supported if the total itemsize is unchanged"
+    )
     def test_score_returns_score(self):
         """
         Test that ConfusionMatrix score() returns a score between 0 and 1

--- a/tests/test_classifier/test_threshold.py
+++ b/tests/test_classifier/test_threshold.py
@@ -295,7 +295,7 @@ class TestDiscriminationThreshold(VisualTestCase, DatasetMixin):
         assert viz._check_cv(splits, random_state=23).random_state == 23
 
         splits = StratifiedShuffleSplit(n_splits=1, random_state=181)
-        assert viz._check_cv(splits, random_state=None).random_state is 181
+        assert viz._check_cv(splits, random_state=None).random_state == 181
         assert viz._check_cv(splits, random_state=72).random_state == 72
 
     def test_bad_exclude(self):

--- a/tests/test_contrib/test_scatter.py
+++ b/tests/test_contrib/test_scatter.py
@@ -16,6 +16,7 @@ Test the ScatterViz feature analysis visualizers
 # Imports
 ##########################################################################
 
+import sys
 import pytest
 import numpy as np
 import matplotlib as mptl
@@ -137,6 +138,9 @@ class ScatterVizTests(VisualTestCase, DatasetMixin):
             self.assertTrue(
                 'only accepts two features' in str(context.exception))
 
+    @pytest.mark.xfail(
+        sys.platform == 'win32', reason="Changing the dtype to a subarray type is only supported if the total itemsize is unchanged"
+    )
     def test_integrated_scatter(self):
         """
         Test scatter on the real, occupancy data set
@@ -174,7 +178,9 @@ class ScatterVizTests(VisualTestCase, DatasetMixin):
         assert "alpha" in scatter_kwargs
         assert scatter_kwargs["alpha"] == 0.7
 
-
+    @pytest.mark.xfail(
+        sys.platform == 'win32', reason="Changing the dtype to a subarray type is only supported if the total itemsize is unchanged"
+    )
     def test_scatter_quick_method(self):
         """
         Test scatter quick method on the real, occupancy data set
@@ -217,6 +223,9 @@ class ScatterVizTests(VisualTestCase, DatasetMixin):
         visualizer = ScatterViz(features=features)
         visualizer.fit_transform_poof(X, y)
 
+    @pytest.mark.xfail(
+        sys.platform == 'win32', reason="Changing the dtype to a subarray type is only supported if the total itemsize is unchanged"
+    )
     def test_integrated_scatter_numpy_named_arrays(self):
         """
         Test scatterviz on numpy named arrays


### PR DESCRIPTION
This hotfix primarily adds matplotlib3 support by requiring any version of mpl except for 3.0.0 which had a backend bug that affected Yellowbrick.

@ianozsvald thanks for your note on #701 -- I'm not sure at this point what would be required to hotfix 0.9, we've made a lot of significant changes for our upcoming v1.0 release. However, I've created this PR to see what our CI tools think of the hotfix. Stay tuned!