### PR TITLE
Workaround for AppVeyor Miniconda3 Tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,21 +40,21 @@ matrix:
     fast_finish: true
 
 install:
-    - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
-    - conda update --all"
-    - "%PYTHON%\\python.exe -m pip install wheel"
-    - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
-    - "%PYTHON%\\python.exe -m pip install -r tests/requirements.txt"
-    - "%PYTHON%\\python.exe -m nltk.downloader popular"
+    - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+    - "python -m pip install -U pip"
+    - "python -m pip install -U wheel"
+    - "python -m pip install -U -r requirements.txt"
+    - "python -m pip install -U -r tests/requirements.txt"
+    - "python -m nltk.downloader popular"
 
 # No requirement to build any C libraries
 build: off
 
 test_script:
-    - "%PYTHON%\\python.exe setup.py test"
+    - "python setup.py test"
 
 after_test:
-    - "%PYTHON%\\python.exe setup.py bdist_wheel"
+    - "python setup.py bdist_wheel"
 
 artifacts:
     - path: dist\*

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,17 +10,19 @@ environment:
         #   PYTHON_VERSION: "2.7.14"
         #   PYTHON_ARCH: "32"
 
-        - PYTHON: "C:\\Python27-x64"
-          PYTHON_VERSION: "2.7.14"
-          PYTHON_ARCH: "64"
+        # TODO: Put back in (for testing only)
+        # - PYTHON: "C:\\Python27-x64"
+        #   PYTHON_VERSION: "2.7.14"
+        #   PYTHON_ARCH: "64"
 
         # - PYTHON: "C:\\Python36"
         #   PYTHON_VERSION: "3.6.4"
         #   PYTHON_ARCH: "32"
 
-        - PYTHON: "C:\\Python36-x64"
-          PYTHON_VERSION: "3.6.4"
-          PYTHON_ARCH: "64"
+        # TODO: Put back in (for testing only)
+        # - PYTHON: "C:\\Python36-x64"
+        #   PYTHON_VERSION: "3.6.4"
+        #   PYTHON_ARCH: "64"
 
         # - PYTHON: "C:\\Miniconda3"
         #   PYTHON_VERSION: "3.6.4"
@@ -38,6 +40,7 @@ matrix:
     fast_finish: true
 
 install:
+    - "%MINICONDA%\\Scripts\\conda update --all"
     - "%PYTHON%\\python.exe -m pip install wheel"
     - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
     - "%PYTHON%\\python.exe -m pip install -r tests/requirements.txt"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,6 +40,7 @@ matrix:
     fast_finish: true
 
 install:
+    - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
     - conda update --all"
     - "%PYTHON%\\python.exe -m pip install wheel"
     - "%PYTHON%\\python.exe -m pip install -r requirements.txt"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,10 @@
 # AppVeyor is a CI service to build and run tests under Windows
 # https://ci.appveyor.com/project/districtdatalabs/yellowbrick
 
+# Temporary work around see #744
+image:
+  - Previous Visual Studio 2015
+
 environment:
 
     matrix:
@@ -27,11 +31,10 @@ environment:
         #   MINICONDA_VERSION: "4.4.10"
         #   PYTHON_ARCH: "32"
 
-        # Currently broken, see #744
-        # - PYTHON: "C:\\Miniconda3-x64"
-        #   PYTHON_VERSION: "3.6.4"
-        #   MINICONDA_VERSION: "4.5.12"
-        #   PYTHON_ARCH: "64"
+        - PYTHON: "C:\\Miniconda3-x64"
+          PYTHON_VERSION: "3.6.4"
+          MINICONDA_VERSION: "4.5.12"
+          PYTHON_ARCH: "64"
 
 
 # Cancel pending jobs after first job failure

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,7 +40,7 @@ matrix:
     fast_finish: true
 
 install:
-    - "%MINICONDA%\\Scripts\\conda update --all"
+    - conda update --all"
     - "%PYTHON%\\python.exe -m pip install wheel"
     - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
     - "%PYTHON%\\python.exe -m pip install -r tests/requirements.txt"
@@ -68,7 +68,6 @@ notifications:
         - bbengfort@districtdatalabs.com
         - rbilbro@districtdatalabs.com
         - nathan.danielsen@gmail.com
-        - tojeda@districtdatalabs.com
       on_build_success: false
       on_build_failure: false
       on_build_status_changed: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ environment:
         #   PYTHON_ARCH: "32"
 
         - PYTHON: "C:\\Miniconda3-x64"
-          PYTHON_VERSION: "3.7.2"
+          PYTHON_VERSION: "3.6.4"
           MINICONDA_VERSION: "4.5.12"
           PYTHON_ARCH: "64"
 
@@ -46,7 +46,8 @@ install:
     - "python -m pip install -U wheel"
     - "python -m pip install -U -r requirements.txt"
     - "python -m pip install -U -r tests/requirements.txt"
-    - "python -m nltk.downloader popular"
+    - "python -m pip uninstall -y nltk"
+    # - "python -m nltk.downloader popular"
 
 # No requirement to build any C libraries
 build: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ environment:
 
         - PYTHON: "C:\\Miniconda3-x64"
           PYTHON_VERSION: "3.6.4"
-          MINICONDA_VERSION: "4.4.10"
+          MINICONDA_VERSION: "4.5.12"
           PYTHON_ARCH: "64"
 
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,6 +40,7 @@ matrix:
     fast_finish: true
 
 install:
+    - "SET PATH=%MINICONDA3%;%MINICONDA3%\\Scripts;%PATH%"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "python -m pip install -U pip"
     - "python -m pip install -U wheel"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,6 +42,7 @@ matrix:
 install:
     - "SET PATH=%MINICONDA3%;%MINICONDA3%\\Scripts;%PATH%"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+    - "conda update --all"
     - "python -m pip install -U pip"
     - "python -m pip install -U wheel"
     - "python -m pip install -U -r requirements.txt"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ environment:
         #   PYTHON_ARCH: "32"
 
         - PYTHON: "C:\\Miniconda3-x64"
-          PYTHON_VERSION: "3.6.4"
+          PYTHON_VERSION: "3.7.2"
           MINICONDA_VERSION: "4.5.12"
           PYTHON_ARCH: "64"
 
@@ -42,7 +42,6 @@ matrix:
 install:
     - "SET PATH=%MINICONDA3%;%MINICONDA3%\\Scripts;%PATH%"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-    - "conda update --all"
     - "python -m pip install -U pip"
     - "python -m pip install -U wheel"
     - "python -m pip install -U -r requirements.txt"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,29 +10,28 @@ environment:
         #   PYTHON_VERSION: "2.7.14"
         #   PYTHON_ARCH: "32"
 
-        # TODO: Put back in (for testing only)
-        # - PYTHON: "C:\\Python27-x64"
-        #   PYTHON_VERSION: "2.7.14"
-        #   PYTHON_ARCH: "64"
+        - PYTHON: "C:\\Python27-x64"
+          PYTHON_VERSION: "2.7.14"
+          PYTHON_ARCH: "64"
 
         # - PYTHON: "C:\\Python36"
         #   PYTHON_VERSION: "3.6.4"
         #   PYTHON_ARCH: "32"
 
-        # TODO: Put back in (for testing only)
-        # - PYTHON: "C:\\Python36-x64"
-        #   PYTHON_VERSION: "3.6.4"
-        #   PYTHON_ARCH: "64"
+        - PYTHON: "C:\\Python36-x64"
+          PYTHON_VERSION: "3.6.4"
+          PYTHON_ARCH: "64"
 
         # - PYTHON: "C:\\Miniconda3"
         #   PYTHON_VERSION: "3.6.4"
         #   MINICONDA_VERSION: "4.4.10"
         #   PYTHON_ARCH: "32"
 
-        - PYTHON: "C:\\Miniconda3-x64"
-          PYTHON_VERSION: "3.6.4"
-          MINICONDA_VERSION: "4.5.12"
-          PYTHON_ARCH: "64"
+        # Currently broken, see #744
+        # - PYTHON: "C:\\Miniconda3-x64"
+        #   PYTHON_VERSION: "3.6.4"
+        #   MINICONDA_VERSION: "4.5.12"
+        #   PYTHON_ARCH: "64"
 
 
 # Cancel pending jobs after first job failure
@@ -46,8 +45,7 @@ install:
     - "python -m pip install -U wheel"
     - "python -m pip install -U -r requirements.txt"
     - "python -m pip install -U -r tests/requirements.txt"
-    - "python -m pip uninstall -y nltk"
-    # - "python -m nltk.downloader popular"
+    - "python -m nltk.downloader popular"
 
 # No requirement to build any C libraries
 build: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,5 @@ notifications:
       - bbengfort@districtdatalabs.com
       - rbilbro@districtdatalabs.com
       - nathan.danielsen@gmail.com
-      - tojeda@districtdatalabs.com
     on_success: change
     on_failure: always

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -12,7 +12,7 @@ pytest-flakes>=4.0.0
 #pytest-spec>=1.1.0
 coverage>=4.5.2
 requests>=2.18.3
-six==1.11.0
+six>=1.11.0
 
 # Python 2 Testing Requirements
 mock>=2.0.0


### PR DESCRIPTION
This PR is a workaround to the issue described in #744 by using the "Previous Visual Studio 2015" image rather than the current CI image. 

See [discussion here](https://help.appveyor.com/discussions/problems/20308-importerror-dll-load-failed-the-specified-module-could-not-be-found).