### PR TITLE
Attempt to reintegrate spec and verbose as pytest addopts

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,7 @@ tests = True
 test=pytest
 
 [tool:pytest]
-# TODO: add --spec and --verbose back to addopts
-addopts = --cov=yellowbrick --flakes
+addopts = --verbose --cov=yellowbrick --flakes --spec
 python_files = tests/*
 flakes-ignore =
     __init__.py UnusedImport

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,10 +6,10 @@ numpy>=1.13.0
 cycler>=0.10.0
 
 # Testing Requirements
-pytest>=4.2.0
+pytest>=4.2.1
 pytest-cov>=2.6.1
 pytest-flakes>=4.0.0
-#pytest-spec>=1.1.0
+pytest-spec>=1.1.0
 coverage>=4.5.2
 requests>=2.18.3
 six>=1.11.0


### PR DESCRIPTION
This PR is an attempt to reintegrate spec and verbose as `pytest` `addopts`, by bumping the `pytest` version and reincorporating `pytest-spec`. We had to remove this in #712 due to an update to `pytest 4.2` that broke our tests, which means we no longer have quite as nice a test reporting output format. 

I noticed that `pytest 4.2.1` [was just released this week](https://twitter.com/nicoddemus/status/1095634334437048320) and thought it might be worth a shot to see if the new version resolved the bug that removed the `_genid` attribute from the test obj. If this works, it will fix #714, otherwise we can just close this PR, keep #714 open, and wait for the next `pytest` version.