### PR TITLE
Fixed incorrect link to teaching with YB slidedeck

### DIFF
--- a/docs/teaching.rst
+++ b/docs/teaching.rst
@@ -18,7 +18,7 @@ The following slide deck presents an approach to teaching students about the mac
 
 .. raw:: html
 
-    <iframe src="https://www.slideshare.net/RebeccaBilbro/slideshelf" width="615px" height="470px" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:none;" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe>
+    <iframe src="https://www.slideshare.net/slideshow/embed_code/key/3ltBl9qX9w7uXk" width="595" height="485" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe> <div style="margin-bottom:5px"> <strong> <a href="//www.slideshare.net/RebeccaBilbro/learning-machine-learning-with-yellowbrick" title="Learning machine learning with Yellowbrick" target="_blank">Learning machine learning with Yellowbrick</a> </strong> from <strong><a href="//www.slideshare.net/RebeccaBilbro" target="_blank">Rebecca Bilbro</a></strong> </div>
 
 
 Teachers are welcome to `download the slides <https://www.slideshare.net/RebeccaBilbro/learning-machine-learning-with-yellowbrick>`_ via SlideShare as a PowerPoint deck, and to add them to their course materials to assist in teaching these important concepts.


### PR DESCRIPTION
Just realized that the original link to the "Teaching ML with YB" slidedeck in the docs was to speakerdeck and not to the specific slides (so the link worked, but each time new slides were uploaded, that new deck appeared first instead of the intended deck). This PR updates the link by pinning to the specific slide deck that teachers can use for teaching with YB in their courses.