### PR TITLE
Added normalization technique 'maxabs' reference to ParallelCoordinates documentation (DistrictDataLabs #797)

### DIFF
--- a/docs/api/features/pcoords.rst
+++ b/docs/api/features/pcoords.rst
@@ -41,7 +41,7 @@ By inspecting the visualization closely, we can see that the combination of tran
 
 Unfortunately, as we inspect this class, we can see that the domain of each feature may make the visualization hard to interpret. In the above visualization, the domain of the ``light`` feature is from in ``[0, 1600]``, far larger than the range of temperature in ``[50, 96]``. To solve this problem, each feature should be scaled or normalized so they are approximately in the same domain.
 
-Normalization techniques can be directly applied to the visualizer without pre-transforming the data (though you could also do this) by using the ``normalize`` parameter. Several transformers are available; try using ``minmax``, ``standard``, ``l1``, or ``l2`` normalization to change perspectives in the parallel coordinates as follows:
+Normalization techniques can be directly applied to the visualizer without pre-transforming the data (though you could also do this) by using the ``normalize`` parameter. Several transformers are available; try using ``minmax``, ``maxabs``, ``standard``, ``l1``, or ``l2`` normalization to change perspectives in the parallel coordinates as follows:
 
 .. plot::
     :context: close-figs


### PR DESCRIPTION
The normalization technique 'maxabs' is a supported method for ParallelCoordinates which is not referenced in the documentation. 