### PR TITLE
Addressing issue #590:Adding train alpha and test alpha to residual

### DIFF
--- a/tests/test_regressor/test_residuals.py
+++ b/tests/test_regressor/test_residuals.py
@@ -358,12 +358,12 @@ class TestResidualsPlot(VisualTestCase, DatasetMixin):
         visualizer = ResidualsPlot(
             Ridge(random_state=8893), train_alpha=0.3,test_alpha=0.75, hist=False
         )
-        alpha = {
+        alphas = {
                 'train_point': 0.3,
                 'test_point':0.75
         }
         # Test param gets set correctly
-        assert visualizer.alpha == alpha
+        assert visualizer.alphas == alphas
 
         visualizer.ax = mock.MagicMock()
         visualizer.fit(self.data.X.train, self.data.y.train)

--- a/tests/test_regressor/test_residuals.py
+++ b/tests/test_regressor/test_residuals.py
@@ -239,7 +239,7 @@ class TestResidualsPlot(VisualTestCase, DatasetMixin):
         visualizer.score(self.data.X.test, self.data.y.test)
         visualizer.finalize()
 
-        self.assert_images_similar(visualizer, tol=10, remove_legend=True)
+        self.assert_images_similar(visualizer, tol=1, remove_legend=True)
 
     @pytest.mark.xfail(
         sys.platform == 'win32', reason="images not close on windows (RMSE=32)"
@@ -258,7 +258,7 @@ class TestResidualsPlot(VisualTestCase, DatasetMixin):
         visualizer.score(self.data.X.test, self.data.y.test)
         visualizer.finalize()
 
-        self.assert_images_similar(visualizer, tol=10, remove_legend=True)
+        self.assert_images_similar(visualizer, tol=1, remove_legend=True)
 
     @pytest.mark.skipif(MPL_VERS_MAJ >= 2, reason="test requires mpl earlier than 2.0.2")
     def test_hist_matplotlib_version(self, mock_toolkit):
@@ -300,7 +300,7 @@ class TestResidualsPlot(VisualTestCase, DatasetMixin):
             model, self.data.X.train, self.data.y.train, ax=ax, random_state=23
         )
 
-        self.assert_images_similar(ax=ax, tol=10, remove_legend=True)
+        self.assert_images_similar(ax=ax, tol=1, remove_legend=True)
 
     @pytest.mark.xfail(
         sys.platform == 'win32', reason="images not close on windows (RMSE=32)"
@@ -334,7 +334,7 @@ class TestResidualsPlot(VisualTestCase, DatasetMixin):
         visualizer.score(X_test, y_test)
         visualizer.finalize()
 
-        self.assert_images_similar(visualizer, tol=10, remove_legend=True)
+        self.assert_images_similar(visualizer, tol=1, remove_legend=True)
 
     def test_score(self):
         """
@@ -360,7 +360,7 @@ class TestResidualsPlot(VisualTestCase, DatasetMixin):
         )
         alphas = {
                 'train_point': 0.3,
-                'test_point':0.75
+                'test_point': 0.75
         }
         # Test param gets set correctly
         assert visualizer.alphas == alphas

--- a/tests/test_regressor/test_residuals.py
+++ b/tests/test_regressor/test_residuals.py
@@ -239,7 +239,7 @@ class TestResidualsPlot(VisualTestCase, DatasetMixin):
         visualizer.score(self.data.X.test, self.data.y.test)
         visualizer.finalize()
 
-        self.assert_images_similar(visualizer, tol=1, remove_legend=True)
+        self.assert_images_similar(visualizer, tol=10, remove_legend=True)
 
     @pytest.mark.xfail(
         sys.platform == 'win32', reason="images not close on windows (RMSE=32)"
@@ -258,7 +258,7 @@ class TestResidualsPlot(VisualTestCase, DatasetMixin):
         visualizer.score(self.data.X.test, self.data.y.test)
         visualizer.finalize()
 
-        self.assert_images_similar(visualizer, tol=1, remove_legend=True)
+        self.assert_images_similar(visualizer, tol=10, remove_legend=True)
 
     @pytest.mark.skipif(MPL_VERS_MAJ >= 2, reason="test requires mpl earlier than 2.0.2")
     def test_hist_matplotlib_version(self, mock_toolkit):
@@ -300,7 +300,7 @@ class TestResidualsPlot(VisualTestCase, DatasetMixin):
             model, self.data.X.train, self.data.y.train, ax=ax, random_state=23
         )
 
-        self.assert_images_similar(ax=ax, tol=1, remove_legend=True)
+        self.assert_images_similar(ax=ax, tol=10, remove_legend=True)
 
     @pytest.mark.xfail(
         sys.platform == 'win32', reason="images not close on windows (RMSE=32)"
@@ -334,7 +334,7 @@ class TestResidualsPlot(VisualTestCase, DatasetMixin):
         visualizer.score(X_test, y_test)
         visualizer.finalize()
 
-        self.assert_images_similar(visualizer, tol=1, remove_legend=True)
+        self.assert_images_similar(visualizer, tol=10, remove_legend=True)
 
     def test_score(self):
         """
@@ -356,11 +356,14 @@ class TestResidualsPlot(VisualTestCase, DatasetMixin):
         """
         # Instantiate a prediction error plot, provide custom alpha
         visualizer = ResidualsPlot(
-            Ridge(random_state=8893), alpha=0.3, hist=False
+            Ridge(random_state=8893), train_alpha=0.3,test_alpha=0.75, hist=False
         )
-
+        alpha = {
+                'train_point': 0.3,
+                'test_point':0.75
+        }
         # Test param gets set correctly
-        assert visualizer.alpha == 0.3
+        assert visualizer.alpha == alpha
 
         visualizer.ax = mock.MagicMock()
         visualizer.fit(self.data.X.train, self.data.y.train)
@@ -369,4 +372,4 @@ class TestResidualsPlot(VisualTestCase, DatasetMixin):
         # Test that alpha was passed to internal matplotlib scatterplot
         _, scatter_kwargs = visualizer.ax.scatter.call_args
         assert "alpha" in scatter_kwargs
-        assert scatter_kwargs["alpha"] == 0.3
+        assert scatter_kwargs["alpha"] == 0.75

--- a/yellowbrick/regressor/residuals.py
+++ b/yellowbrick/regressor/residuals.py
@@ -371,12 +371,12 @@ class ResidualsPlot(RegressionScoreVisualizer):
     line_color : color, default: dark grey
         Defines the color of the zero error line, can be any matplotlib color.
 
-    train_alpha : float, default: 1
+    train_alpha : float, default: 0.75
         Specify a transparency for traininig data, where 1 is completely opaque 
         and 0 is completely transparent. This property makes densely clustered 
         points more visible.
     
-    test_alpha : float, default: 1
+    test_alpha : float, default: 0.75
         Specify a transparency for test data, where 1 is completely opaque 
         and 0 is completely transparent. This property makes densely clustered 
         points more visible.
@@ -403,8 +403,8 @@ class ResidualsPlot(RegressionScoreVisualizer):
     The residuals histogram feature requires matplotlib 2.0.2 or greater.
     """
     def __init__(self, model, ax=None, hist=True, train_color='b',
-                 test_color='g', line_color=LINE_COLOR, train_alpha=1,
-                 test_alpha=1,**kwargs):
+                 test_color='g', line_color=LINE_COLOR, train_alpha=0.75,
+                 test_alpha=0.75,**kwargs):
 
         super(ResidualsPlot, self).__init__(model, ax=ax, **kwargs)
 
@@ -429,7 +429,7 @@ class ResidualsPlot(RegressionScoreVisualizer):
         # Store labels and colors for the legend ordered by call
         self._labels, self._colors = [], []
 
-        self.alpha = {
+        self.alphas = {
                 'train_point': train_alpha,
                 'test_point':test_alpha
         }
@@ -538,11 +538,11 @@ class ResidualsPlot(RegressionScoreVisualizer):
         if train:
             color = self.colors['train_point']
             label = "Train $R^2 = {:0.3f}$".format(self.train_score_)
-            alpha = self.alpha['train_point']
+            alpha = self.alphas['train_point']
         else:
             color = self.colors['test_point']
             label = "Test $R^2 = {:0.3f}$".format(self.test_score_)
-            alpha = self.alpha['test_point']
+            alpha = self.alphas['test_point']
             
         # Update the legend information
         self._labels.append(label)
@@ -605,8 +605,8 @@ def residuals_plot(model,
                    test_color='g',
                    line_color=LINE_COLOR,
                    random_state=None,
-                   train_alpha=1,
-                   test_alpha=1,
+                   train_alpha=0.75,
+                   test_alpha=0.75,
                    **kwargs):
     """Quick method:
 
@@ -661,12 +661,12 @@ def residuals_plot(model,
     random_state : int, RandomState instance or None, optional
         Passed to the train_test_split function.
 
-    train_alpha : float, default: 1
+    train_alpha : float, default: 0.75
         Specify a transparency for traininig data, where 1 is completely opaque 
         and 0 is completely transparent. This property makes densely clustered 
         points more visible.
     
-    test_alpha : float, default: 1
+    test_alpha : float, default: 0.75
         Specify a transparency for test data, where 1 is completely opaque and 
         0 is completely transparent. This property makes densely clustered 
         points more visible.
@@ -684,7 +684,8 @@ def residuals_plot(model,
     
     visualizer = ResidualsPlot(
         model=model, ax=ax, hist=hist, train_color=train_color,
-        test_color=test_color, line_color=line_color, train_alpha=train_alpha,test_alpha=test_alpha,
+        test_color=test_color, line_color=line_color, 
+        train_alpha=train_alpha,test_alpha=test_alpha,
         **kwargs
     )
 

--- a/yellowbrick/regressor/residuals.py
+++ b/yellowbrick/regressor/residuals.py
@@ -161,6 +161,7 @@ class PredictionError(RegressionScoreVisualizer):
         return self.score_
 
     def draw(self, y, y_pred):
+        
         """
         Parameters
         ----------
@@ -370,9 +371,15 @@ class ResidualsPlot(RegressionScoreVisualizer):
     line_color : color, default: dark grey
         Defines the color of the zero error line, can be any matplotlib color.
 
-    alpha : float, default: 0.75
-        Specify a transparency where 1 is completely opaque and 0 is completely
-        transparent. This property makes densely clustered points more visible.
+    train_alpha : float, default: 1
+        Specify a transparency for traininig data, where 1 is completely opaque 
+        and 0 is completely transparent. This property makes densely clustered 
+        points more visible.
+    
+    test_alpha : float, default: 1
+        Specify a transparency for test data, where 1 is completely opaque 
+        and 0 is completely transparent. This property makes densely clustered 
+        points more visible.
 
     kwargs : dict
         Keyword arguments that are passed to the base class and may influence
@@ -396,8 +403,8 @@ class ResidualsPlot(RegressionScoreVisualizer):
     The residuals histogram feature requires matplotlib 2.0.2 or greater.
     """
     def __init__(self, model, ax=None, hist=True, train_color='b',
-                 test_color='g', line_color=LINE_COLOR, alpha=0.75,
-                 **kwargs):
+                 test_color='g', line_color=LINE_COLOR, train_alpha=1,
+                 test_alpha=1,**kwargs):
 
         super(ResidualsPlot, self).__init__(model, ax=ax, **kwargs)
 
@@ -422,7 +429,10 @@ class ResidualsPlot(RegressionScoreVisualizer):
         # Store labels and colors for the legend ordered by call
         self._labels, self._colors = [], []
 
-        self.alpha = alpha
+        self.alpha = {
+                'train_point': train_alpha,
+                'test_point':test_alpha
+        }
 
     @memoized
     def hax(self):
@@ -496,7 +506,7 @@ class ResidualsPlot(RegressionScoreVisualizer):
         y_pred = self.predict(X)
         scores = y_pred - y
         self.draw(y_pred, scores, train=train)
-
+        
         return score
 
     def draw(self, y_pred, residuals, train=False, **kwargs):
@@ -528,17 +538,19 @@ class ResidualsPlot(RegressionScoreVisualizer):
         if train:
             color = self.colors['train_point']
             label = "Train $R^2 = {:0.3f}$".format(self.train_score_)
+            alpha = self.alpha['train_point']
         else:
             color = self.colors['test_point']
             label = "Test $R^2 = {:0.3f}$".format(self.test_score_)
-
+            alpha = self.alpha['test_point']
+            
         # Update the legend information
         self._labels.append(label)
         self._colors.append(color)
 
         # Draw the residuals scatter plot
         self.ax.scatter(
-            y_pred, residuals, c=color, alpha=self.alpha, label=label
+            y_pred, residuals, c=color, alpha=alpha, label=label
         )
 
         # Add residuals histogram
@@ -593,7 +605,8 @@ def residuals_plot(model,
                    test_color='g',
                    line_color=LINE_COLOR,
                    random_state=None,
-                   alpha=0.75,
+                   train_alpha=1,
+                   test_alpha=1,
                    **kwargs):
     """Quick method:
 
@@ -648,9 +661,15 @@ def residuals_plot(model,
     random_state : int, RandomState instance or None, optional
         Passed to the train_test_split function.
 
-    alpha : float, default: 0.75
-        Specify a transparency where 1 is completely opaque and 0 is completely
-        transparent. This property makes densely clustered points more visible.
+    train_alpha : float, default: 1
+        Specify a transparency for traininig data, where 1 is completely opaque 
+        and 0 is completely transparent. This property makes densely clustered 
+        points more visible.
+    
+    test_alpha : float, default: 1
+        Specify a transparency for test data, where 1 is completely opaque and 
+        0 is completely transparent. This property makes densely clustered 
+        points more visible.
 
     kwargs : dict
         Keyword arguments that are passed to the base class and may influence
@@ -662,9 +681,10 @@ def residuals_plot(model,
         Returns the axes that the residuals plot was drawn on.
     """
     # Instantiate the visualizer
+    
     visualizer = ResidualsPlot(
         model=model, ax=ax, hist=hist, train_color=train_color,
-        test_color=test_color, line_color=line_color, alpha=alpha,
+        test_color=test_color, line_color=line_color, train_alpha=train_alpha,test_alpha=test_alpha,
         **kwargs
     )
 

--- a/yellowbrick/regressor/residuals.py
+++ b/yellowbrick/regressor/residuals.py
@@ -431,7 +431,7 @@ class ResidualsPlot(RegressionScoreVisualizer):
 
         self.alphas = {
                 'train_point': train_alpha,
-                'test_point':test_alpha
+                'test_point': test_alpha
         }
 
     @memoized


### PR DESCRIPTION
The following changes were made to Residuals referenced in #590:

1. Added new parameters train_alpha and test_alpha to specify the opacity of train and test data respectively in `residuals.py`
2. Modified the `test_residuals.py`

The result obtained is attached below:
![Figure_1](https://user-images.githubusercontent.com/43993586/55667432-d6d3c280-5879-11e9-87fc-8fc6fb470117.png)
