### PR TITLE
Makes grammar and readability edits addressing issue #843

### DIFF
--- a/docs/contributing/developing_visualizers.rst
+++ b/docs/contributing/developing_visualizers.rst
@@ -9,7 +9,7 @@ In this section, we'll discuss the basics of developing visualizers. This of cou
 
     <iframe src="https://www.slideshare.net/BenjaminBengfort/slideshelf" width="615px" height="470px" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:none;" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe>
 
-One thing that is necessary is a good understanding of scikit-learn and Matplotlib. Because our API is intended to integrate with scikit-learn, a good start is to review `"APIs of scikit-learn objects" <http://scikit-learn.org/stable/developers/contributing.html#apis-of-scikit-learn-objects>`_ and `"rolling your own estimator" <http://scikit-learn.org/stable/developers/contributing.html#rolling-your-own-estimator>`_. In terms of matplotlib, use Yellowbrick's guide :doc:`../matplotlib`. Additional resources include `Nicolas P. Rougier's Matplotlib tutorial <https://www.labri.fr/perso/nrougier/teaching/matplotlib/>`_ and `Chris Moffitt's Effectively Using Matplotlib <http://pbpython.com/effective-matplotlib.html>`_.
+A good understanding of scikit-learn and Matplotlib is a necessity. Because our API is intended to integrate with scikit-learn, a good start is to review `"APIs of scikit-learn objects" <http://scikit-learn.org/stable/developers/contributing.html#apis-of-scikit-learn-objects>`_ and `"rolling your own estimator" <http://scikit-learn.org/stable/developers/contributing.html#rolling-your-own-estimator>`_. In terms of matplotlib, use Yellowbrick's guide :doc:`../matplotlib`. Additional resources include `Nicolas P. Rougier's Matplotlib tutorial <https://www.labri.fr/perso/nrougier/teaching/matplotlib/>`_ and `Chris Moffitt's Effectively Using Matplotlib <http://pbpython.com/effective-matplotlib.html>`_.
 
 Visualizer API
 --------------
@@ -248,7 +248,7 @@ This is a pretty good structure for a documentation page; a brief introduction f
 
 At this point there are several places where you can list your visualizer, but to ensure it is included in the documentation it *must be listed in the TOC of the local index*. Find the ``index.rst`` file in your subdirectory and add your rst file (without the ``.rst`` extension) to the ``..toctree::`` directive. This will ensure the documentation is included when it is built.
 
-Building the Docs 
+Building the Docs
 ~~~~~~~~~~~~~~~~~
 
 Speaking of, you can build your documentation by changing into the ``docs`` directory and running ``make html``, the documentation will be built and rendered in the ``_build/html`` directory. You can view it by opening ``_build/html/index.html`` then navigating to your documentation in the browser.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -7,7 +7,7 @@ In this tutorial, we are going to look at scores for a variety of `Scikit-Learn 
 
 The Model Selection Triple
 --------------------------
-Discussions of machine learning are frequently characterized by a singular focus on model selection. Be it logistic regression, random forests, Bayesian methods, or artificial neural networks, machine learning practitioners are often quick to express their preference. The reason for this is mostly historical. Though modern third-party machine learning libraries have made the deployment of multiple models appear nearly trivial, traditionally the application and tuning of even one of these algorithms required many years of study. As a result, machine learning practitioners tended to have strong preferences for particular (and likely more familiar) models over others.
+Discussions of machine learning are frequently characterized by a singular focus on model selection. Be it logistic regression, random forests, Bayesian methods, or artificial neural networks, machine learning practitioners are often quick to express their preference. The reason for this is mostly historical. Though modern third-party machine learning libraries have made the deployment of multiple models appear nearly trivial, traditionally the application and tuning of even one of these algorithms required many years of study. As a result, machine learning practitioners tended to be more familiar with and or express strong preferences for particular models over others.
 
 However, model selection is a bit more nuanced than simply picking the "right" or "wrong" algorithm. In practice, the workflow includes:
 
@@ -56,7 +56,7 @@ Let's load the data:
 Feature Extraction
 ------------------
 
-Our data, including the target, is categorical. We will need to change these values to numeric ones for machine learning. In order to extract this from the dataset, we'll have to use scikit-learn transformers to transform our input dataset into something that can be fit to a model. Luckily, scikit-learn does provide transformers for converting categorical labels into numeric integers: 
+Our data, including the target, is categorical. We will need to change these values to numeric values for machine learning. In order to extract this from the dataset, we'll have to use scikit-learn transformers to transform our input dataset into something that can be fit to a model. Luckily, scikit-learn does provide transformers for converting categorical labels into numeric integers:
 `sklearn.preprocessing.LabelEncoder <http://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.LabelEncoder.html>`__ and `sklearn.preprocessing.OneHotEncoder <http://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html>`__.
 
 We'll use a combination of scikit-learn's ``Pipeline`` object (`here's <http://zacstewart.com/2014/08/05/pipelines-of-featureunions-of-pipelines.html>`__ a great post on using pipelines by `Zac Stewart <https://twitter.com/zacstewart>`__), ``OneHotEncoder``, and ``LabelEncoder``:
@@ -67,14 +67,14 @@ We'll use a combination of scikit-learn's ``Pipeline`` object (`here's <http://z
     from sklearn.preprocessing import OneHotEncoder, LabelEncoder
 
     # Label-encode targets before modeling
-    y = LabelEncoder().fit_transform(y) 
+    y = LabelEncoder().fit_transform(y)
 
     # One-hot encode columns before modeling
     model = Pipeline([
-     ('one_hot_encoder', OneHotEncoder()), 
+     ('one_hot_encoder', OneHotEncoder()),
      ('estimator', estimator)
     ])
- 
+
 Modeling and Evaluation
 -----------------------
 
@@ -118,13 +118,13 @@ diagnostics from the Yellowbrick library).
     from sklearn.preprocessing import OneHotEncoder, LabelEncoder
     from sklearn.linear_model import LogisticRegressionCV, LogisticRegression, SGDClassifier
     from sklearn.ensemble import BaggingClassifier, ExtraTreesClassifier, RandomForestClassifier
-    
-        
+
+
     models = [
-        SVC(gamma='auto'), NuSVC(gamma='auto'), LinearSVC(), 
-        SGDClassifier(max_iter=100, tol=1e-3), KNeighborsClassifier(), 
-        LogisticRegression(solver='lbfgs'), LogisticRegressionCV(cv=3), 
-        BaggingClassifier(), ExtraTreesClassifier(n_estimators=300), 
+        SVC(gamma='auto'), NuSVC(gamma='auto'), LinearSVC(),
+        SGDClassifier(max_iter=100, tol=1e-3), KNeighborsClassifier(),
+        LogisticRegression(solver='lbfgs'), LogisticRegressionCV(cv=3),
+        BaggingClassifier(), ExtraTreesClassifier(n_estimators=300),
         RandomForestClassifier(n_estimators=300)
     ]
 
@@ -132,19 +132,19 @@ diagnostics from the Yellowbrick library).
     def score_model(X, y, estimator, **kwargs):
         """
         Test various estimators.
-        """ 
+        """
         y = LabelEncoder().fit_transform(y)
         model = Pipeline([
-            ('one_hot_encoder', OneHotEncoder()), 
+            ('one_hot_encoder', OneHotEncoder()),
             ('estimator', estimator)
         ])
 
         # Instantiate the classification model and visualizer
-        model.fit(X, y, **kwargs)  
-        
+        model.fit(X, y, **kwargs)
+
         expected  = y
         predicted = model.predict(X)
-        
+
         # Compute and return F1 (harmonic mean of precision and recall)
         print("{}: {}".format(estimator.__class__.__name__, f1_score(expected, predicted)))
 
@@ -189,21 +189,21 @@ Now let's refactor our model evaluation function to use Yellowbrick's ``Classifi
     def visualize_model(X, y, estimator, **kwargs):
         """
         Test various estimators.
-        """ 
+        """
         y = LabelEncoder().fit_transform(y)
         model = Pipeline([
-            ('one_hot_encoder', OneHotEncoder()), 
+            ('one_hot_encoder', OneHotEncoder()),
             ('estimator', estimator)
         ])
 
         # Instantiate the classification model and visualizer
         visualizer = ClassificationReport(
-            model, classes=['edible', 'poisonous'], 
+            model, classes=['edible', 'poisonous'],
             cmap="YlGn", size=(600, 360), **kwargs
         )
-        visualizer.fit(X, y)  
+        visualizer.fit(X, y)
         visualizer.score(X, y)
-        visualizer.poof()  
+        visualizer.poof()
 
     for model in models:
         visualize_model(X, y, model)


### PR DESCRIPTION
Change the docs to fix one grammar error and one revision to make
the docs more concise.


### Summary: 
This PR fixes #issue_number #843 
I have made changes to the following files: 
* yellowbrick/docs/tutorial.rst in the 'Model Selection Triple' & 'Feature Extraction' sections.
* yellowbrick/docs/contributing/getting_started.rst in the 'Forking the Repository' section.
* yellowbrick/docs/contributing/developing_visualizers.rst in the 'Developing Visualizers' section.

The changes would fix one grammatical error and make the writing more concise
I have made the following changes    
1.   reword a sentence phrase previously written "(and likely more familiar)"   
2.  change a word from "ones" to "values"
3.   reword phrase "one thing that is necessary is X" to "X is a necessity"



