### PR TITLE
Doc updates to address waffle, PR procedure, and NLTK reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ For more on the development path, goals, and motivations behind Yellowbrick, che
 
 Yellowbrick is an open source project that is supported by a community who will gratefully and humbly accept any contributions you might make to the project. Large or small, any contribution makes a big difference; and if you've never contributed to an open source project before, we hope you will start with Yellowbrick!
 
-Principally, Yellowbrick development is about the addition and creation of *visualizers* --- objects that learn from data and create a visual representation of the data or model. Visualizers integrate with scikit-learn estimators, transformers, and pipelines for specific purposes and as a result, can be simple to build and deploy. The most common contribution is therefore a new visualizer for a specific model or model family. We'll discuss in detail how to build visualizers later.
+Principally, Yellowbrick development is about the addition and creation of *visualizers* &mdash; objects that learn from data and create a visual representation of the data or model. Visualizers integrate with scikit-learn estimators, transformers, and pipelines for specific purposes and as a result, can be simple to build and deploy. The most common contribution is therefore a new visualizer for a specific model or model family. We'll discuss in detail how to build visualizers later.
 
 Beyond creating visualizers, there are many ways to contribute:
 
@@ -30,18 +30,17 @@ Yellowbrick is hosted on GitHub at https://github.com/DistrictDataLabs/yellowbri
 
 The typical workflow for a contributor to the codebase is as follows:
 
-1. **Discover** a bug or a feature by using Yellowbrick.
+1. **Discover** a bug or a feature by using Yellowbrick. 
 2. **Discuss** with the core contributes by [adding an issue](https://github.com/DistrictDataLabs/yellowbrick/issues).
-3. **Assign** yourself the task by pulling a card from our [Waffle Kanban](https://waffle.io/DistrictDataLabs/yellowbrick).
-4. **Fork** the repository into your own GitHub account.
-5. Create a **Pull Request** first thing to [connect with us](https://github.com/DistrictDataLabs/yellowbrick/pulls) about your task.
-6. **Code** the feature, write the documentation, add your contribution.
-7. **Review** the code with core contributors who will guide you to a high quality submission.
-8. **Merge** your contribution into the Yellowbrick codebase.
+3. **Fork** the repository into your own GitHub account.
+4. Create a **Pull Request** first thing to [connect with us](https://github.com/DistrictDataLabs/yellowbrick/pulls) about your task.
+5. **Code** the feature, write the documentation, add your contribution.
+6. **Review** the code with core contributors who will guide you to a high quality submission.
+7. **Merge** your contribution into the Yellowbrick codebase.
 
-**Note**: Create a pull request as soon as possible, even before you've started coding. This will allow the core contributors to give you advice about where to add your code or utilities and discuss other style choices and implementation details as you go. Don't wait!
+We believe that *contribution is collaboration* and therefore emphasize *communication* throughout the open source process. We rely heavily on GitHub's social coding tools to allow us to do this. For instance, we use GitHub's [milestone](https://help.github.com/en/articles/about-milestones) feature to focus our development efforts for each Yellowbrick semester, so be sure to check out the issues associated with our [current milestone](https://github.com/districtdatalabs/yellowbrick/milestones)!
 
-We believe that *contribution is collaboration* and therefore emphasize *communication* throughout the open source process. We rely heavily on GitHub's social coding tools to allow us to do this.
+Once you have a good sense of how you are going to implement the new feature (or fix the bug!), you can reach out for feedback from the maintainers by creating a [pull request](https://github.com/DistrictDataLabs/yellowbrick/pulls). Please note that if we feel your solution has not been thought out in earnest, or if the PR is not aligned with our [current milestone](https://github.com/districtdatalabs/yellowbrick/milestones) goals, we may reach out to ask that you close the PR so that we can prioritize reviewing the most critical feature requests and bug fixes.
 
 Ideally, any pull request should be capable of resolution within 6 weeks of being opened. This timeline helps to keep our pull request queue small and allows Yellowbrick to maintain a robust release schedule to give our users the best experience possible. However, the most important thing is to keep the dialogue going! And if you're unsure whether you can complete your idea within 6 weeks, you should still go ahead and open a PR and we will be happy to help you scope it down as needed.
 
@@ -104,7 +103,7 @@ Once forked, use the following steps to get your development environment set up 
     $ git checkout develop
     ```
 
-At this point you're ready to get started writing code. If you're going to take on a specific task, we'd strongly encourage you to check out the issue on [Waffle](https://waffle.io/DistrictDataLabs/yellowbrick) and create a [pull request](https://github.com/DistrictDataLabs/yellowbrick/pulls) **before you start coding** to better foster communication with other contributors.
+At this point you're ready to get started writing code!
 
 ### Branching Conventions
 
@@ -144,7 +143,7 @@ $ git branch -d feature-myfeature
 $ git push origin --delete feature-myfeature
 ```
 
-Head back to Waffle and checkout another issue!
+Head back to Github and checkout another issue!
 
 ## Developing Visualizers
 
@@ -304,7 +303,3 @@ class MyVisualizer(Visualizer):
 ```
 
 This is a very good start to producing a high quality visualizer, but unless it is part of the documentation on our website, it will not be visible. For details on including documentation in the `docs` directory see the [Contributing Documentation](http://www.scikit-yb.org/en/latest/contributing.html#documentation) section in the larger contributing guide.
-
-## Throughput
-
-[![Throughput Graph](https://graphs.waffle.io/DistrictDataLabs/yellowbrick/throughput.svg)](https://waffle.io/DistrictDataLabs/yellowbrick/metrics/throughput)

--- a/docs/contributing/getting_started.rst
+++ b/docs/contributing/getting_started.rst
@@ -9,16 +9,19 @@ The typical workflow for a contributor to the codebase is as follows:
 
 1. **Discover** a bug or a feature by using Yellowbrick.
 2. **Discuss** with the core contributors by `adding an issue <https://github.com/DistrictDataLabs/yellowbrick/issues>`_.
-3. **Assign** yourself the task by pulling a card from our `Waffle Kanban <https://waffle.io/DistrictDataLabs/yellowbrick>`_
-4. **Fork** the repository into your own GitHub account.
-5. Create a **Pull Request** first thing to `connect with us <https://github.com/DistrictDataLabs/yellowbrick/pulls>`_ about your task.
-6. **Code** the feature, write the tests and documentation, add your contribution.
-7. **Review** the code with core contributors who will guide you to a high quality submission.
-8. **Merge** your contribution into the Yellowbrick codebase.
+3. **Fork** the repository into your own GitHub account.
+4. Create a **Pull Request** first thing to `connect with us <https://github.com/DistrictDataLabs/yellowbrick/pulls>`_ about your task.
+5. **Code** the feature, write the tests and documentation, add your contribution.
+6. **Review** the code with core contributors who will guide you to a high quality submission.
+7. **Merge** your contribution into the Yellowbrick codebase.
 
-.. note:: Please create a pull request as soon as possible, even before you've started coding. This will allow the core contributors to give you advice about where to add your code or utilities and discuss other style choices and implementation details as you go. Don't wait!
+We believe that *contribution is collaboration* and therefore emphasize *communication* throughout the open source process. We rely heavily on GitHub's social coding tools to allow us to do this. For instance, we use GitHub's `milestone <https://help.github.com/en/articles/about-milestones>`_ feature to focus our development efforts for each Yellowbrick semester, so be sure to check out the issues associated with our `current milestone <https://github.com/districtdatalabs/yellowbrick/milestones>`_!
 
-We believe that *contribution is collaboration* and therefore emphasize *communication* throughout the open source process. We rely heavily on GitHub's social coding tools to allow us to do this.
+Once you have a good sense of how you are going to implement the new feature (or fix the bug!), you can reach out for feedback from the maintainers by creating a `pull request <https://github.com/DistrictDataLabs/yellowbrick/pulls>`_. Ideally, any pull request should be capable of resolution within 6 weeks of being opened. This timeline helps to keep our pull request queue small and allows Yellowbrick to maintain a robust release schedule to give our users the best experience possible. However, the most important thing is to keep the dialogue going! And if you're unsure whether you can complete your idea within 6 weeks, you should still go ahead and open a PR and we will be happy to help you scope it down as needed.
+
+If we have comments or questions when we evaluate your pull request and receive no response, we will also close the PR after this period of time. Please know that this does not mean we don't value your contribution, just that things go stale. If in the future you want to pick it back up, feel free to address our original feedback and to reference the original PR in a new pull request. 
+
+.. note:: Please note that if we feel your solution has not been thought out in earnest, or if the PR is not aligned with our `current milestone <https://github.com/districtdatalabs/yellowbrick/milestones>`_ goals, we may reach out to ask that you close the PR so that we can prioritize reviewing the most critical feature requests and bug fixes.
 
 Forking the Repository
 ----------------------
@@ -62,7 +65,7 @@ Once forked, use the following steps to get your development environment set up 
         $ git fetch
         $ git checkout develop
 
-At this point you're ready to get started writing code. If you're going to take on a specific task, we'd strongly encourage you to check out the issue on `Waffle <https://waffle.io/DistrictDataLabs/yellowbrick>`_ and create a `pull request <https://github.com/DistrictDataLabs/yellowbrick/pulls>`_ *before you start coding* to better foster communication with other contributors. More on this in the next section.
+At this point you're ready to get started writing code. 
 
 Branching Convention
 --------------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -9,7 +9,7 @@ Yellowbrick has two primary dependencies: `scikit-learn <http://scikit-learn.org
 
 Yellowbrick is also commonly used inside of a `Jupyter Notebook <http://jupyter.org/>`_ alongside `Pandas <http://pandas.pydata.org/>`_ data frames. Notebooks make it especially easy to coordinate code and visualizations; however, you can also use Yellowbrick inside of regular Python scripts, either saving figures to disk or showing figures in a GUI window. If you're having trouble with this, please consult matplotlib's `backends documentation <https://matplotlib.org/faq/usage_faq.html#what-is-a-backend>`_.
 
-.. NOTE:: Jupyter, Pandas, and other ancillary libraries like NLTK for text visualizers are not installed with Yellowbrick and must be installed separately.
+.. NOTE:: Jupyter, Pandas, and other ancillary libraries like the Natural Language Toolkit (NLTK) for text visualizers are not installed with Yellowbrick and must be installed separately.
 
 Installation
 ------------


### PR DESCRIPTION
This PR executes a few minor documentation changes:
 - clarifies procedures for submitting PRs by giving a sense of what to expect from ideation to completion (closes #849)
 - removes references to waffle (which is being deprecated) (closes #850)
 - adds full name of NLTK (closes #841) 