### PR TITLE
Temporarily sidestep matplotlib 3.1.0 in tests

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 # Library Dependencies
-matplotlib>=1.5.1,!=3.0.0
+matplotlib>=1.5.1,!=3.0.0, !=3.1.0
 scipy>=1.0.0
 scikit-learn>=0.20
 numpy>=1.13.0


### PR DESCRIPTION
We've been experiencing a new set of CI test failures on Travis and Appveyor; it looks like the newest version of Matplotlib, which was released two days ago, [has made changes to how the backend is set](https://matplotlib.org/3.1.0/users/whats_new.html). 

As a result, when we run [`matplotlib.use("Agg")` for our tests](https://github.com/DistrictDataLabs/yellowbrick/blob/develop/tests/__init__.py#L24), it doesn't seem to work as expected anymore. This manifests in CI as a few image comparison failures (e.g. with `RFECV` and `ClassBalance`), but on my Mac it *also* results in about 75 of these: 
```
base.py:72: in setUp
    self.assertEqual(self._backend, 'agg')
E   AssertionError: 'MacOSX' != 'agg'
E   - MacOSX
E   + agg
```

In this PR, I've updated our `tests/requirements.txt` to temporarily avoid matplotlib 3.1.0 so that we can set the backend to agg as we have been doing. However, we will need to come back to this and address it more comprehensively in [v1.0](https://github.com/DistrictDataLabs/yellowbrick/milestone/13). Related: #707 #690 #823