### PR TITLE
Adding support for PALETTES to return colormap

### DIFF
--- a/yellowbrick/style/colors.py
+++ b/yellowbrick/style/colors.py
@@ -89,7 +89,13 @@ def resolve_colors(n_colors=None, colormap=None, colors=None):
     if colormap is not None and colors is None:
         if isinstance(colormap, str):
             try:
-                colormap = cm.get_cmap(colormap)
+                # Must import here to avoid recursive import
+                from .palettes import PALETTES
+
+                _colormap = PALETTES.get(colormap, None)
+                if _colormap is None:
+                    _colormap = cm.get_cmap(colormap)
+                colormap = _colormap
             except ValueError as e:
                 raise YellowbrickValueError(e)
 


### PR DESCRIPTION
This PR fixes #855 which was reported by @mgarod when solving #837 

I have made the following changes    
1.  Added an import for PALETTES in the try block in resolve_colors()
2.  Defaulting to the matplotlib colormap, if colormap is non-existent in PALETTES

Questions for the @DistrictDataLabs/@mgarod:
- [ ]   Is this the expected solution to this issue?

