### PR TITLE
PR Template Revisions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,52 +1,73 @@
-### Welcome, Contributor! 
-This template is meant to get your PR started off on the right foot.
+<!--
+# Welcome Contributor!
 
-### I. Are you merging from a feature branch into develop?
-_If not, please create a feature branch and change your PR to merge from that branch into Yellowbrick `develop`._
+Thank you for contributing to Yellowbrick, please follow the instructions below to get
+your PR started off on the right foot.
 
-### II. Does your PR have a title?
-_Please ensure your PR has a short, informative title, e.g. "Enhances ParallelCoordinates with new andrews_curve parameter" or "Corrects bug in WhiskerPlot that causes index error"_
+## First Steps
 
-### III. Summarize your PR (HINT: See CHECKLIST below!)
+1. Are you merging from a feature branch into develop?
+
+    _If not, please create a feature branch and change your PR to merge from that branch
+    into the Yellowbrick `develop` branch._
+
+2. Does your PR have a title?
+
+    _Please ensure your PR has a short, informative title, e.g. "Enhances ParallelCoordinates with new andrews_curve parameter" or "Corrects bug in WhiskerPlot that causes index error"_
+
+3. Summarize your PR (HINT: See CHECKLIST/TEMPLATE below!)
+-->
+
 This PR fixes #issue_number _(If you are fixing a bug)_ which reported a bug that caused a problem to occur when users...
+
 _(or if you are introducing a new feature)_ which requested a feature to allow the user to...
 
-I have made the following changes    
-1.      
-2.     
-3.     
+I have made the following changes:
 
-### IV. Include a sample plot
-_If you are adding or modifying a visualizer, PLEASE include a sample plot here._
+1.
+2.
+3.
 
-### V. List any TODOs or questions
-_If this is a work-in-progress (WIP), list the changes you still need to make and/or questions or the Yellowbrick team:_
+### Sample Code and Plot
+
+_If you are adding or modifying a visualizer, PLEASE include a sample plot here along with the code you used to generate it._
+
+### TODOs and questions
+
+<!--
+If this is a work-in-progress (WIP), list the changes you still need to make and/or questions or the Yellowbrick team. You can also mention extensions to your work that might be added as an issue to work on after the PR.
+-->
 
 Still to do:
-- [ ]     
-- [ ]     
-- [ ]     
+
+- [ ]
+- [ ]
+- [ ]
 
 Questions for the @DistrictDataLabs/team-oz-maintainers:
-- [ ]     
-- [ ]      
 
-### VI. CHECKLIST
-_Here's a handy checklist to go through before submitting a PR_
-- _Is the commit message formatted correctly?_
-- _Have you noted the new functionality/bugfix in the release notes of the next release?_
+- [ ]
+- [ ]
 
-_If you've changed any code_
-- _Included a sample plot to visually illustrate your changes?_
-- _Do all of your functions and methods have docstrings?_
-- _Have you added/updated unit tests where appropriate?_ 
-- _Have you updated the baseline images if necessary?_
-- _Have you run the unit tests using `pytest`?_
-- _Is your code style correct (are you using PEP8, pyflakes)?_
-- _Have you documented your new feature/functionality in the docs?_
-     
-_If you've added to the docs_
-- _Have you built the docs using `make html`?_
+### CHECKLIST
 
+<!--
+Here's a handy checklist to go through before submitting a PR, note that you can check a checkbox in Markdown by changing `- [ ]` to `- [x]` or you can create the PR and check the box manually.
+-->
 
+- [ ] _Is the commit message formatted correctly?_
+- [ ] _Have you noted the new functionality/bugfix in the release notes of the next release?_
 
+<!-- If you've changed any code -->
+
+- [ ] _Included a sample plot to visually illustrate your changes?_
+- [ ] _Do all of your functions and methods have docstrings?_
+- [ ] _Have you added/updated unit tests where appropriate?_
+- [ ] _Have you updated the baseline images if necessary?_
+- [ ] _Have you run the unit tests using `pytest`?_
+- [ ] _Is your code style correct (are you using PEP8, pyflakes)?_
+- [ ] _Have you documented your new feature/functionality in the docs?_
+
+<!-- If you've added to the docs -->
+
+- [ ] _Have you built the docs using `make html`?_


### PR DESCRIPTION
@rebeccabilbro here are the revisions I mentioned yesterday. Basically, I've put the instructions in HTML comments so that the contributor can use the template to mostly fill in the blanks. There is still plenty of uncommented content, so it will be easy to tell if a contributor submits without using the template. Additionally, I've turned the checklist into a checkbox checklist so that the maintainers can also check things off as they're doing their review (it may not be a bad idea to put a maintainer checklist in the template as well). 