### PR TITLE
comment out 4.5.12 miniconda build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,10 +41,11 @@ environment:
           MINICONDA_VERSION: "4.5.4"
           PYTHON_ARCH: "64"
 
-        - PYTHON: "C:\\Miniconda37-x64"
-          PYTHON_VERSION: "3.7"
-          MINICONDA_VERSION: "4.5.12"
-          PYTHON_ARCH: "64"
+        # Failing Tests Due to TypeError: LoadLibrary()
+        # - PYTHON: "C:\\Miniconda37-x64"
+        #   PYTHON_VERSION: "3.7"
+        #   MINICONDA_VERSION: "4.5.12"
+        #   PYTHON_ARCH: "64"
 
 
 # Cancel pending jobs after first job failure


### PR DESCRIPTION
Commenting out appveyor tests for MINICONDA_VERSION: "4.5.12"

Failing Tests Due to TypeError: LoadLibrary()

This seems to be a possible solution, but CI is building slowly:
https://github.com/mattwthompson/mbuild/commit/963ff7832f247cd77afaeec168988c99e3ccb6c0
