### PR TITLE
Add new oneliners page to the YB docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,15 +14,11 @@ Yellowbrick extends the Scikit-Learn API to make model selection and hyperparame
 Recommended Learning Path
 -------------------------
 
-1. Check out the :doc:`quickstart`
+1. Check out the :doc:`quickstart`, try the :doc:`tutorial`, and check out the :doc:`oneliners`.
 
-2. Try the the :doc:`tutorial`.
+2. Use Yellowbrick in your work, referencing the :doc:`api/index` for assistance with specific visualizers and detailed information on optional parameters and customization options.
 
-3. Use Yellowbrick in your project.
-
-4. For details on specific Visualizers and extended usage head over to the :doc:`api/index`.
-
-5. Follow us on Twitter `@scikit_yb <https://twitter.com/scikit_yb>`_. You'll hear about new visualizers as they're added.
+3. Star us on `GitHub <https://github.com/DistrictDataLabs/yellowbrick/>`_ and follow us on `Twitter (@scikit_yb) <https://twitter.com/scikit_yb>`_ so that you'll hear about new visualizers as soon as they're added.
 
 Contributing
 ------------
@@ -149,13 +145,14 @@ Table of Contents
    quickstart
    tutorial
    api/index
-   evaluation
+   oneliners
    contributing/index
    matplotlib
    teaching
    gallery
    about
    faq
+   evaluation
    code_of_conduct
    changelog
    governance/index

--- a/docs/oneliners.rst
+++ b/docs/oneliners.rst
@@ -1,0 +1,347 @@
+.. -*- mode: rst -*-
+
+Oneliners
+=========
+
+Yellowbrick's quick methods are visualizers in a single line of code!
+
+Yellowbrick is designed to give you as much control as you would like over the plots you create, offering parameters to help you customize everything from color, size, and title to preferred evaluation or correlation measure, optional bestfit lines or histograms, and cross validation techniques. To learn more about how to customize your visualizations using those parameters, check out the :doc:`api/index`.
+
+But... sometimes you just want to build a plot with a single line of code!
+
+On this page we'll explore the Yellowbrick quick methods (aka "oneliners"), which return a fully fitted, finalized visualizer object in only a single line.
+
+.. note:: This page illustrates oneliners for some of our most popular visualizers for feature analysis, classification, regression, clustering, and target evaluation, but is not a comprehensive list. Nearly every Yellowbrick visualizer has an associated quick method!
+
+Feature Analysis
+----------------
+
+Rank2D
+~~~~~~
+
+The ``rank1d`` and ``rank2d`` plots show pairwise rankings of features to help you detect relationships. More about :doc:`api/features/rankd`.
+
+.. plot::
+    :context: close-figs
+    :alt: Rank2D Quick Method
+
+    from yellowbrick.features import rank2d
+    from yellowbrick.datasets import load_credit
+
+
+    X, _ = load_credit()
+    visualizer = rank2d(X)
+
+.. plot::
+    :context: close-figs
+    :alt: Rank1D Quick Method
+
+    from yellowbrick.features import rank1d
+    from yellowbrick.datasets import load_energy
+
+
+    X, _ = load_energy()
+    visualizer = rank1d(X, color="r")
+
+
+Parallel Coordinates
+~~~~~~~~~~~~~~~~~~~~
+
+The ``parallel_coordinates`` plot is a horizontal visualization of instances, disaggregated by the features that describe them. More about :doc:`api/features/pcoords`.
+
+.. plot::
+    :context: close-figs
+    :alt: Parallel Coordinates Quick Method
+
+    from sklearn.datasets import load_wine
+    from yellowbrick.features import parallel_coordinates
+
+
+    X, y = load_wine(return_X_y=True)
+    visualizer = parallel_coordinates(X, y, normalize="standard")
+
+
+Radial Visualization
+~~~~~~~~~~~~~~~~~~~~
+
+The ``radviz`` plot shows the separation of instances around a unit circle. More about :doc:`api/features/radviz`.
+
+.. plot::
+    :context: close-figs
+    :alt: Radviz Quick Method
+
+    from yellowbrick.features import radviz
+    from yellowbrick.datasets import load_occupancy
+
+
+    X, y = load_occupancy()
+    visualizer = radviz(X, y, colors=["maroon", "gold"])
+
+
+PCA
+~~~
+
+A ``pca_decomposition`` is a projection of instances based on principal components. More about :doc:`api/features/pca`.
+
+.. plot::
+    :context: close-figs
+    :alt: PCA Quick Method
+
+    from yellowbrick.datasets import load_spam
+    from yellowbrick.features import pca_decomposition
+
+
+    X, y = load_spam()
+    visualizer = pca_decomposition(X, y)
+
+
+Manifold
+~~~~~~~~
+
+The ``manifold_embedding`` plot is a high dimensional visualization with manifold learning, which can show nonlinear relationships in the features. More about :doc:`api/features/manifold`.
+
+.. plot::
+    :context: close-figs
+    :alt: Manifold Quick Method
+
+    from sklearn.datasets import load_iris
+    from yellowbrick.features import manifold_embedding
+
+
+    X, y = load_iris(return_X_y=True)
+    visualizer = manifold_embedding(X, y)
+
+
+Classification
+--------------
+
+Class Prediction Error
+~~~~~~~~~~~~~~~~~~~~~~
+
+A ``class_prediction_error`` plot illustrates the error and support in a classification as a bar chart. More about :doc:`api/classifier/class_prediction_error`.
+
+.. plot::
+    :context: close-figs
+    :alt: Class Prediction Error Quick Method
+
+    from yellowbrick.datasets import load_game
+    from sklearn.preprocessing import OneHotEncoder
+    from sklearn.ensemble import RandomForestClassifier
+    from yellowbrick.classifier import class_prediction_error
+
+
+    X, y = load_game()
+    X = OneHotEncoder().fit_transform(X)
+    visualizer = class_prediction_error(
+        RandomForestClassifier(n_estimators=10), X, y
+    )
+
+
+Classification Report
+~~~~~~~~~~~~~~~~~~~~~
+
+A ``classification_report`` is a visual representation of precision, recall, and F1 score. More about :doc:`api/classifier/classification_report`.
+
+.. plot::
+    :context: close-figs
+    :alt: Classification Report Quick Method
+
+    from yellowbrick.datasets import load_credit
+    from sklearn.ensemble import RandomForestClassifier
+    from yellowbrick.classifier import classification_report
+
+
+    X, y = load_credit()
+    visualizer = classification_report(
+        RandomForestClassifier(n_estimators=10), X, y
+    )
+
+
+Confusion Matrix
+~~~~~~~~~~~~~~~~
+
+A ``confusion_matrix`` is a visual description of per-class decision making. More about :doc:`api/classifier/confusion_matrix`.
+
+.. plot::
+    :context: close-figs
+    :alt: Confusion Matrix Quick Method
+
+    from yellowbrick.datasets import load_game
+    from sklearn.preprocessing import OneHotEncoder
+    from sklearn.linear_model import RidgeClassifier
+    from yellowbrick.classifier import confusion_matrix
+
+
+    X, y = load_game()
+    X = OneHotEncoder().fit_transform(X)
+    visualizer = confusion_matrix(RidgeClassifier(), X, y, cmap="Greens")
+
+
+Precision Recall
+~~~~~~~~~~~~~~~~
+
+A ``precision_recall_curve`` shows the tradeoff between precision and recall for different probability thresholds. More about :doc:`api/classifier/prcurve`.
+
+.. plot::
+    :context: close-figs
+    :alt: Precision Recall Quick Method
+
+    from sklearn.naive_bayes import GaussianNB
+    from yellowbrick.datasets import load_occupancy
+    from yellowbrick.classifier import precision_recall_curve
+
+
+    X, y = load_occupancy()
+    visualizer = precision_recall_curve(GaussianNB(), X, y)
+
+
+ROCAUC
+~~~~~~
+
+A ``roc_auc`` plot shows the receiver operator characteristics and area under the curve. More about :doc:`api/classifier/rocauc`.
+
+.. plot::
+    :context: close-figs
+    :alt: ROCAUC Quick Method
+
+    from yellowbrick.classifier import roc_auc
+    from yellowbrick.datasets import load_spam
+    from sklearn.linear_model import LogisticRegression
+
+
+    X, y = load_spam()
+    visualizer = roc_auc(LogisticRegression(), X, y)
+
+
+Discrimination Threshold
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+A ``discrimination_threshold`` plot can help find a threshold that best separates binary classes. More about :doc:`api/classifier/threshold`.
+
+.. plot::
+    :context: close-figs
+    :alt: Discrimination Threshold Quick Method
+
+    from yellowbrick.classifier import discrimination_threshold
+    from sklearn.linear_model import LogisticRegression
+    from yellowbrick.datasets import load_spam
+
+    X, y = load_spam()
+    visualizer = discrimination_threshold(
+        LogisticRegression(multi_class="auto", solver="liblinear"), X, y
+    )
+
+
+Regression
+----------
+
+Residuals Plot
+~~~~~~~~~~~~~~
+
+A ``residuals_plot`` shows the difference in residuals between the training and test data. More about :doc:`api/regressor/residuals`.
+
+.. plot::
+    :context: close-figs
+    :alt: Residuals Quick Method
+
+    from sklearn.linear_model import Ridge
+    from yellowbrick.datasets import load_concrete
+    from yellowbrick.regressor import residuals_plot
+
+
+    X, y = load_concrete()
+    visualizer = residuals_plot(
+        Ridge(), X, y, train_color="maroon", test_color="gold"
+    )
+
+Prediction Error
+~~~~~~~~~~~~~~~~
+
+A ``prediction_error`` helps find where the regression is making the most errors. More about :doc:`api/regressor/peplot`.
+
+.. plot::
+    :context: close-figs
+    :alt: Prediction Error Quick Method
+
+    from sklearn.linear_model import Lasso
+    from yellowbrick.datasets import load_bikeshare
+    from yellowbrick.regressor import prediction_error
+
+
+    X, y = load_bikeshare()
+    visualizer = prediction_error(Lasso(), X, y)
+
+
+Cooks Distance
+~~~~~~~~~~~~~~
+
+A ``cooks_distance`` plot shows the influence of instances on linear regression. More about :doc:`api/regressor/influence`.
+
+.. plot::
+    :context: close-figs
+    :alt: Cooks Distance Quick Method
+
+    from sklearn.datasets import load_diabetes
+    from yellowbrick.regressor import cooks_distance
+
+
+    X, y = load_diabetes(return_X_y=True)
+    visualizer = cooks_distance(X, y)
+
+
+Clustering
+----------
+
+Silhouette Scores
+~~~~~~~~~~~~~~~~~
+
+A ``silhouette_visualizer`` can help you select ``k`` by visualizing silhouette coefficient values. More about :doc:`api/cluster/silhouette`.
+
+.. plot::
+    :context: close-figs
+    :alt: Silhouette Scores Quick Method
+
+    from sklearn.cluster import KMeans
+    from yellowbrick.datasets import load_nfl
+    from yellowbrick.cluster import silhouette_visualizer
+
+    X, y = load_nfl()
+    visualizer = silhouette_visualizer(KMeans(5, random_state=42), X)
+
+
+Intercluster Distance
+~~~~~~~~~~~~~~~~~~~~~
+
+A ``intercluster_distance`` shows size and relative distance between clusters. More about :doc:`api/cluster/icdm`.
+
+.. plot::
+    :context: close-figs
+    :alt: ICDM Quick Method
+
+    from yellowbrick.datasets import load_nfl
+    from sklearn.cluster import MiniBatchKMeans
+    from yellowbrick.cluster import intercluster_distance
+
+
+    X, y = load_nfl()
+    visualizer = intercluster_distance(MiniBatchKMeans(5, random_state=777), X)
+
+
+Target Analysis
+---------------
+
+ClassBalance
+~~~~~~~~~~~~
+
+The ``class_balance`` plot can make it easier to see how the distribution of classes may affect the model. More about :doc:`api/target/class_balance`.
+
+.. plot::
+    :context: close-figs
+    :alt: ClassBalance Quick Method
+
+    from yellowbrick.datasets import load_game
+    from yellowbrick.target import class_balance
+
+
+    X, y = load_game()
+    visualizer = class_balance(y, labels=["draw", "loss", "win"])


### PR DESCRIPTION
This PR is a step towards #600, adding a page in our documentation about using the quick methods.

I have made the following changes:

1. Added a `oneliners.rst` to the `docs`; the page uses the plot directive to auto-generate the images when the docs are built.
2. Updated the `index.rst` to reference `oneliners.rst`
