### PR TITLE
Correct latex formatting in elbow legend

### DIFF
--- a/yellowbrick/cluster/elbow.py
+++ b/yellowbrick/cluster/elbow.py
@@ -358,7 +358,7 @@ class KElbowVisualizer(ClusteringScoreVisualizer):
         # Plot the silhouette score against k
         self.ax.plot(self.k_values_, self.k_scores_, marker="D")
         if self.locate_elbow is True and self.elbow_value_ is not None:
-            elbow_label = "$elbow at k={}, score={:0.3f}$".format(
+            elbow_label = "elbow at $k={}$, $score={:0.3f}$".format(
                 self.elbow_value_, self.elbow_score_
             )
             self.ax.axvline(
@@ -398,7 +398,7 @@ class KElbowVisualizer(ClusteringScoreVisualizer):
 
         # set the legend if locate_elbow=True
         if self.locate_elbow is True and self.elbow_value_ is not None:
-            self.ax.legend(loc="best", fontsize="medium")
+            self.ax.legend(loc="best", fontsize="medium", frameon=True)
 
         # Set the second y axis labels
         if self.timings:


### PR DESCRIPTION
This PR corrects the latex formatting in the legend of the `KElbowVisualizer` to close #1058, and also turns `frameon=True` for the legend to make it a bit easier to see over the gridlines and plot.

### Sample Plot

Formerly:
![image](https://user-images.githubusercontent.com/8760385/79920658-98666280-83fe-11ea-8bda-7e15bb12a87f.png)

With this change:
![image](https://user-images.githubusercontent.com/8760385/79920634-871d5600-83fe-11ea-8d3d-19a372a85973.png)


### CHECKLIST


- [x] _Is the commit message formatted correctly?_
- [ ] _Have you noted the new functionality/bugfix in the release notes of the next release?_
- [x] _Included a sample plot to visually illustrate your changes?_
- [x] _Do all of your functions and methods have docstrings?_
- [ ] _Have you added/updated unit tests where appropriate?_
- [ ] _Have you updated the baseline images if necessary?_
- [x] _Have you run the unit tests using `pytest`?_
- [x] _Is your code style correct (are you using PEP8, pyflakes)?_
- [ ] _Have you documented your new feature/functionality in the docs?_
- [x] _Have you built the docs using `make html`?_
