### PR TITLE
Typo fix and cleanup to rocauc file

### DIFF
--- a/docs/api/classifier/rocauc.rst
+++ b/docs/api/classifier/rocauc.rst
@@ -52,8 +52,7 @@ Workflow             Model evaluation
 Multi-class ROCAUC Curves
 -------------------------
 
-Yellowbrick's ``ROCAUC`` Visualizer does allow for plotting multiclass classification curves.
-ROC curves are typically used in binary classification, and in fact the Scikit-Learn ``roc_curve`` metric is only able to perform metrics for binary classifiers. Yellowbrick addresses this by binarizing the output (per-class) or to use one-vs-rest (micro score) or one-vs-all (macro score) strategies of classification.
+Yellowbrick's ``ROCAUC`` Visualizer does allow for plotting multiclass classification curves. ROC curves are typically used in binary classification, and in fact the Scikit-Learn ``roc_curve`` metric is only able to perform metrics for binary classifiers. Yellowbrick addresses this by binarizing the output (per-class) or to use one-vs-rest (micro score) or one-vs-all (macro score) strategies of classification.
 
 .. plot::
     :context: close-figs

--- a/yellowbrick/classifier/rocauc.py
+++ b/yellowbrick/classifier/rocauc.py
@@ -208,7 +208,7 @@ class ROCAUC(ClassificationScoreVisualizer):
 
         # Set the visual parameters for ROCAUC
         # NOTE: the binary flag breaks our API since it's really just a meta parameter
-        # for micro, macro, and per_class. We knew this going into it, but did it anyway.
+        # for micro, macro, and per_class. We knew this going in, but did it anyway.
         if binary:
             self.set_params(micro=False, macro=False, per_class=False)
         else:
@@ -261,10 +261,11 @@ class ROCAUC(ClassificationScoreVisualizer):
         y_pred = self._get_y_scores(X)
 
         if self.target_type_ == BINARY:
-            # If it's binary classification, to draw micro or macro curves per_class must be True
+            # For binary, per_class must be True to draw micro/macro curves
             if (self.micro or self.macro) and not self.per_class:
                 raise ModelError(
-                    "no curves will be drawn; set per_class=True or micro=False and macro=False."
+                    "no curves will be drawn; ",
+                    "set per_class=True or micro=False and macro=False.",
                 )
         if self.target_type_ == MULTICLASS:
             # If it's multiclass classification, at least one of micro, macro, or
@@ -284,7 +285,7 @@ class ROCAUC(ClassificationScoreVisualizer):
         self.tpr = dict()
         self.roc_auc = dict()
 
-        # If the decision is binary draw only ROC curve for the postitive class
+        # If the decision is binary draw only ROC curve for the positive class
         if self.target_type_ is BINARY and not self.per_class:
             # In this case predict_proba returns an array of shape (n, 2) which
             # specifies the probabilities of both the negative and positive classes.
@@ -430,7 +431,7 @@ class ROCAUC(ClassificationScoreVisualizer):
         self.ax.set_ylim([0.0, 1.0])
 
         # Set x and y axis labels
-        self.ax.set_ylabel("True Postive Rate")
+        self.ax.set_ylabel("True Positive Rate")
         self.ax.set_xlabel("False Positive Rate")
 
     def _get_y_scores(self, X):
@@ -563,7 +564,7 @@ def roc_auc(
 
     y_train : array-like, 2D
         The vector of target data or the dependent variable predicted by X. Used to fit
-        the visualizer and also to score the visualizer if test splits are not specified.
+        the visualizer and also to score the visualizer if test splits not specified.
 
     X_test: array-like, 2D, default: None
         The table of instance data or independent variables that describe the outcome of
@@ -694,7 +695,8 @@ def roc_auc(
     # Fit and transform the visualizer (calls draw)
     visualizer.fit(X_train, y_train, **kwargs)
 
-    # Scores the visualizer with X_test and y_test if provided, X_train, y_train if not provided
+    # Scores the visualizer with X_test and y_test if provided,
+    # X_train, y_train if not provided
     if X_test is not None and y_test is not None:
         visualizer.score(X_test, y_test)
     else:


### PR DESCRIPTION
This is a very small PR that does some minor cleanup to the rocauc file, including correcting a typo I noticed while teaching this weekend, which resulted in a mislabeled y-axis. 
_Note: tests will pass as soon as we merged #1068 into `develop` and sync this branch up!_

Old version:
![image](https://user-images.githubusercontent.com/8760385/83972827-5d39c900-a8b0-11ea-8a53-0f73e0370f82.png)

New version:
![image](https://user-images.githubusercontent.com/8760385/83972810-4bf0bc80-a8b0-11ea-9173-83912fb6599f.png)


### CHECKLIST

- [x] _Is the commit message formatted correctly?_
- [ ] _Have you noted the new functionality/bugfix in the release notes of the next release?_
- [x] _Included a sample plot to visually illustrate your changes?_
- [x] _Do all of your functions and methods have docstrings?_
- [x] _Have you added/updated unit tests where appropriate?_
- [x] _Have you updated the baseline images if necessary?_
- [x] _Have you run the unit tests using `pytest`?_
- [x] _Is your code style correct (are you using PEP8, pyflakes)?_
- [ ] _Have you documented your new feature/functionality in the docs?_
- [x] _Have you built the docs using `make html`?_
