### PR TITLE
Added pandas as requirements.txt dependency, closes #1082

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,3 +9,5 @@ cycler>=0.10.0
 Sphinx>=2.1
 sphinx-rtd-theme>=0.4.3
 numpydoc>=0.9.0
+pandas>=0.20
+


### PR DESCRIPTION
This PR is meant to fix an issue I identified at #1077, where a plot directive in the Quickstart guide was failing to run because pandas was missing from the docs/requirements.txt file.

<!-- If you've added to the docs -->

- [x] _Have you built the docs using `make html`?_
