### PR TITLE
Non-sklearn dependent estimator check

### DIFF
--- a/yellowbrick/utils/types.py
+++ b/yellowbrick/utils/types.py
@@ -20,8 +20,6 @@ Detection utilities for Scikit-Learn and Numpy types for flexibility
 import inspect
 import numpy as np
 
-from sklearn.base import BaseEstimator
-
 
 ##########################################################################
 ## Model Type checking utilities
@@ -38,10 +36,10 @@ def is_estimator(model):
         The object to test if it is a Scikit-Learn clusterer, especially a
         Scikit-Learn estimator or Yellowbrick visualizer
     """
-    if inspect.isclass(model):
-        return issubclass(model, BaseEstimator)
-
-    return isinstance(model, BaseEstimator)
+    try:
+        return callable(getattr(self, "fit")) and callable(getattr(self, "predict"))
+    except:
+        return False
 
 
 # Alias for closer name to isinstance and issubclass

--- a/yellowbrick/utils/types.py
+++ b/yellowbrick/utils/types.py
@@ -37,7 +37,7 @@ def is_estimator(model):
         Scikit-Learn estimator or Yellowbrick visualizer
     """
     try:
-        return callable(getattr(self, "fit")) and callable(getattr(self, "predict"))
+        return callable(getattr(model, "fit")) and callable(getattr(model, "predict"))
     except:
         return False
 


### PR DESCRIPTION
<!--
# Welcome Contributor!

Thank you for contributing to Yellowbrick, please follow the instructions below to get
your PR started off on the right foot.

## First Steps

1. Are you merging from a feature branch into develop?

    _If not, please create a feature branch and change your PR to merge from that branch
    into the Yellowbrick `develop` branch._

2. Does your PR have a title?

    _Please ensure your PR has a short, informative title, e.g. "Enhances ParallelCoordinates with new andrews_curve parameter" or "Corrects bug in WhiskerPlot that causes index error"_

3. Summarize your PR (HINT: See CHECKLIST/TEMPLATE below!)
-->

The `is_estimator` will return False if the passed object is not an instance of sklearn `BaseEstimator`. This causes issues with eg. https://github.com/rapidsai/cuml, which implements a sklearn API but has their own base class. The proposed change is to check if the object has two critical estimator methods - `fit` and `predict`.

### CHECKLIST

<!--
Here's a handy checklist to go through before submitting a PR, note that you can check a checkbox in Markdown by changing `- [ ]` to `- [x]` or you can create the PR and check the box manually.
-->

- [x] _Is the commit message formatted correctly?_
- [ ] _Have you noted the new functionality/bugfix in the release notes of the next release?_

<!-- If you've changed any code -->

- [ ] _Have you added/updated unit tests where appropriate?_
- [ ] _Have you run the unit tests using `pytest`?_
- [ ] _Is your code style correct (are you using PEP8, pyflakes)?_
- [ ] _Have you documented your new feature/functionality in the docs?_