### PR TITLE
Fixes hanging print impacting model visualizers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,19 @@
 Changelog
 =========
 
+Version 1.3.post1
+-----------------
+
+* Tag: v1.3.post1_
+* Deployed Saturday, February 13, 2021
+* Current Contributors: Rebecca Bilbro, Benjamin Bengfort, (EJ) Vivek Pandey
+
+Fixes hanging print impacting ModelVisualizers.
+
+
+.. _v1.3.post1: https://github.com/DistrictDataLabs/yellowbrick/releases/tag/v1.3.post1
+
+
 Version 1.3
 ------------
 

--- a/yellowbrick/base.py
+++ b/yellowbrick/base.py
@@ -343,7 +343,6 @@ class ModelVisualizer(Visualizer, Wrapper):
         for param in list(params.keys()):
             if param.startswith("estimator__"):
                 params[param[len("estimator__"):]] = params.pop(param)
-        print(params.keys(), "\n\n")
         return params
 
     def set_params(self, **params):


### PR DESCRIPTION
This PR fixes #1153, removing the print inside `set_params` impacting model visualizers
### CHECKLIST

- [x] _Is the commit message formatted correctly?_
- [x] _Have you noted the new functionality/bugfix in the release notes of the next release?_

<!-- If you've changed any code -->

- [ ] _Included a sample plot to visually illustrate your changes?_
- [ ] _Do all of your functions and methods have docstrings?_
- [ ] _Have you added/updated unit tests where appropriate?_
- [ ] _Have you updated the baseline images if necessary?_
- [x] _Have you run the unit tests using `pytest`?_
- [ ] _Is your code style correct (are you using PEP8, pyflakes)?_
- [x] _Have you documented your new feature/functionality in the docs?_

<!-- If you've added to the docs -->

- [x] _Have you built the docs using `make html`?_
