### PR TITLE
Allow Numpy 1.20+

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@
 matplotlib>=3.3
 scipy>=1.6.0
 scikit-learn>=0.24
-numpy>=1.16.0,<1.20
+numpy>=1.16.0
 cycler>=0.10.0
 
 # Documentation Dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 matplotlib>=2.0.2,!=3.0.0
 scipy>=1.0.0
 scikit-learn>=0.20
-numpy>=1.16.0,<1.20
+numpy>=1.16.0
 cycler>=0.10.0
 
 ## Optional Dependencies (uncomment to use)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,23 +4,23 @@
 # are probably using. We recommend monitoring Libraries.io to alert for changes.
 
 # Library Dependencies
-matplotlib==3.4.1
-scipy==1.6.0
-scikit-learn==0.24.1
-numpy==1.20.2
+matplotlib==3.4.2
+scipy==1.7.0
+scikit-learn==0.24.2
+numpy==1.21.0
 cycler==0.10.0
 
 # Testing Requirements
-pytest==6.1.1
-pytest-cov==2.10.1
-pytest-flakes==4.0.2
+pytest==6.2.4
+pytest-cov==2.12.1
+pytest-flakes==4.0.3
 pytest-spec>=2.0.0
-coverage==5.3
+coverage==5.5
 
 # Optional Testing Dependencies
-nltk==3.5
+nltk==3.6.2
 # spacy>=2.0.18
-pandas==1.1.3
+pandas==1.3.0
 umap-learn==0.5.1
 
 # Third-Party Estimator Tests


### PR DESCRIPTION
This follows up on #1176 to also allow Numpy 1.20+ for end users of the library.

The end user problem is that Pip's new dependency resolver can get very ornery when an user attempts to install a new Numpy alongside Yellowbrick; if one is unlucky, it'll spend a long time trying to find a constellation of (various data science) packages that would accept Numpy < 1.20 to satisfy the pin in Yellowbrick's requirements.

This places the onus of properly locking dependency versions (with e.g. `pip-tools` or `poetry`) on the end user, as it should be.

I have made the following changes:

1. Removed the `<1.20` numpy pin from the `requirements.txt` files that had been untouched by #1176.

I've elided editing the changelog here, since it looks like there have been several other changes since 1.3.post1 anyway, and those need to be edited in too...