### PR TITLE
Fix KElbowVisualizer ValueError when null cluster is encountered

### DIFF
--- a/tests/test_cluster/test_elbow.py
+++ b/tests/test_cluster/test_elbow.py
@@ -116,6 +116,15 @@ class TestKElbowHelper(object):
         score = distortion_score(df, s)
         assert score == pytest.approx(69.10006514142941)
 
+    def test_distortion_score_empty_clusters(self):
+        """
+        Ensure no ValueError is thrown when there are empty clusters #1185
+        """
+        X = np.array([[1,2],[3,4],[5,6]])
+        valuea = distortion_score(X, np.array([1,3,3]))
+        valueb = distortion_score(X, np.array([0,1,1]))
+        assert valuea == valueb
+
 
 ##########################################################################
 ## KElbowVisualizer Test Cases
@@ -439,14 +448,14 @@ class TestKElbowVisualizer(VisualTestCase):
         oz.metric_color = "r"
         oz.timing_color = "y"
         oz.vline_color = "c"
-        
+
         # Create artificial "fit" data for testing purposes
         oz.k_values_ = [1, 2, 3, 4, 5, 6, 7, 8]
         oz.k_timers_ = [6.2, 8.3, 10.1, 15.8, 21.2, 27.9, 38.2, 44.9]
         oz.k_scores_ = [.8, .7, .55, .48, .40, .38, .35, .30]
         oz.elbow_value_ = 5
         oz.elbow_score_ = 0.40
-        
+
         # Execute drawing
         oz.draw()
         oz.finalize()

--- a/yellowbrick/cluster/elbow.py
+++ b/yellowbrick/cluster/elbow.py
@@ -88,7 +88,6 @@ def distortion_score(X, labels, metric="euclidean"):
     # Encode labels to get unique centers and groups
     le = LabelEncoder()
     le.fit(labels)
-    # labels = le.fit_transform(labels)
     unique_labels = le.classes_
 
     # Sum of the distortions
@@ -433,15 +432,15 @@ class KElbowVisualizer(ClusteringScoreVisualizer):
     @metric_color.setter
     def metric_color(self, val):
         self.colors[CMETRIC] = val
-    
+
     @property
     def timing_color(self):
         return self.colors[CTIMING]
-    
+
     @timing_color.setter
     def timing_color(self, val):
         self.colors[CTIMING] = val
-    
+
     @property
     def vline_color(self):
         return self.colors[CVLINE]

--- a/yellowbrick/cluster/elbow.py
+++ b/yellowbrick/cluster/elbow.py
@@ -87,7 +87,8 @@ def distortion_score(X, labels, metric="euclidean"):
     """
     # Encode labels to get unique centers and groups
     le = LabelEncoder()
-    labels = le.fit_transform(labels)
+    le.fit(labels)
+    # labels = le.fit_transform(labels)
     unique_labels = le.classes_
 
     # Sum of the distortions


### PR DESCRIPTION
<!--
# Welcome Contributor!

Thank you for contributing to Yellowbrick, please follow the instructions below to get
your PR started off on the right foot.

## First Steps

1. Are you merging from a feature branch into develop?

    _If not, please create a feature branch and change your PR to merge from that branch
    into the Yellowbrick `develop` branch._

2. Does your PR have a title?

    _Please ensure your PR has a short, informative title, e.g. "Enhances ParallelCoordinates with new andrews_curve parameter" or "Corrects bug in WhiskerPlot that causes index error"_

3. Summarize your PR (HINT: See CHECKLIST/TEMPLATE below!)
-->

This PR fixes  #1185 which ValueError is thrown when not all cluster center has at least one input data point assigned to it.

I have made the following changes:

1. Instead of reassigning [`labels = le.fit_transform(labels)`](https://github.com/DistrictDataLabs/yellowbrick/blob/783069e082569463faa3a192d1884de627a13370/yellowbrick/cluster/elbow.py#L90), modification were made to just call `le.fit(labels)` without reassigning input argument `labels`.

### Sample Code and Plot
```
import numpy as np
from yellowbrick.cluster import distortion_score
X = np.array([[1,2],[3,4],[5,6]])
labels = np.array([1,3,3])
print(distortion_score(X, labels))
labels = np.array([0,1,1])
print(distortion_score(X, labels))
```
Console Output
```
4.000000000000001
4.000000000000001
```

### TODOs and questions

<!--
If this is a work-in-progress (WIP), list the changes you still need to make and/or questions or the Yellowbrick team. You can also mention extensions to your work that might be added as an issue to work on after the PR.
-->

Still to do:
None

Questions for the @DistrictDataLabs/team-oz-maintainers:
- Please help me check this is the desired output as I might be wrong.

### CHECKLIST

<!--
Here's a handy checklist to go through before submitting a PR, note that you can check a checkbox in Markdown by changing `- [ ]` to `- [x]` or you can create the PR and check the box manually.
-->

- [x] _Is the commit message formatted correctly?_
- [x] _Have you noted the new functionality/bugfix in the release notes of the next release?_

<!-- If you've changed any code -->

- [x] _Included a sample plot to visually illustrate your changes?_
- [x] _Do all of your functions and methods have docstrings?_
- [ ] _Have you added/updated unit tests where appropriate?_
- [x] _Have you updated the baseline images if necessary?_
- [ ] _Have you run the unit tests using `pytest`?_
- [x] _Is your code style correct (are you using PEP8, pyflakes)?_
- [x] _Have you documented your new feature/functionality in the docs?_

<!-- If you've added to the docs -->

- [ ] _Have you built the docs using `make html`?_
