### PR TITLE
Better argmax handling in DiscriminationThreshold

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ The Yellowbrick repository is set up in a typical production/release/development
 You should work directly in your fork and create a pull request from your fork's develop branch into ours. We also recommend setting up an `upstream` remote so that you can easily pull the latest development changes from the main Yellowbrick repository (see [configuring a remote for a fork](https://help.github.com/articles/configuring-a-remote-for-a-fork/)). You can do that as follows:
 
 ```
-$ git remote add upstream https://github.com/DistrictDataLabs/yellowbrick.git`
+$ git remote add upstream https://github.com/DistrictDataLabs/yellowbrick.git
 $ git remote -v
 origin    https://github.com/YOUR_USERNAME/YOUR_FORK.git (fetch)
 origin    https://github.com/YOUR_USERNAME/YOUR_FORK.git (push)

--- a/tests/test_classifier/test_threshold.py
+++ b/tests/test_classifier/test_threshold.py
@@ -346,3 +346,25 @@ class TestDiscriminationThreshold(VisualTestCase):
 
         with pytest.raises(YellowbrickValueError, match="not a valid metric"):
             DiscriminationThreshold(NuSVC(), exclude=["queue_rate", "foo"])
+
+    def test_bad_argmax(self):
+        """
+        Assert an exception is raised on bad argmax param
+        """
+        with pytest.raises(YellowbrickValueError, match="not a valid metric"):
+            DiscriminationThreshold(NuSVC(), argmax="foo")
+
+    @pytest.mark.parametrize(
+        "viz_kwargs",
+        [
+            {"argmax": None},
+            {"exclude": "fscore"},
+            {"argmax": "queue_rate", "exclude": "queue_rate"},
+        ],
+    )
+    def test_none_argmax(self, viz_kwargs):
+        """
+        Assert argmax param works fine
+        """
+        viz = DiscriminationThreshold(NuSVC(), **viz_kwargs)
+        assert viz._check_argmax(viz.argmax, viz.exclude) is None


### PR DESCRIPTION
Although documentation allows `DiscriminationThreshold(model, argmax=None)`, current implementation raises an exception since it assumes `argmax` to be a string.

I have made the following changes:

1. Allow `argmax` to be `None` (as already documented)
2. Raise error in case `argmax` is an invalid metric (similar to the check of `exclude`)
3. Add tests to check `argmax`
4. Improve docs of `argmax` and `exclude`
5. Fix typo in `CONTRIBUTING.md`


### CHECKLIST

- [x] _Is the commit message formatted correctly?_
- [x] _Have you noted the new functionality/bugfix in the release notes of the next release?_
- [ ] _Included a sample plot to visually illustrate your changes?_
- [x] _Do all of your functions and methods have docstrings?_
- [x] _Have you added/updated unit tests where appropriate?_
- [ ] _Have you updated the baseline images if necessary?_
- [x] _Have you run the unit tests using `pytest`?_
- [x] _Is your code style correct (are you using PEP8, pyflakes)?_
- [ ] _Have you documented your new feature/functionality in the docs?_