### PR TITLE
Fixed #1209 `is_fitted` parameter not setting to given value

### DIFF
--- a/yellowbrick/regressor/prediction_error.py
+++ b/yellowbrick/regressor/prediction_error.py
@@ -121,11 +121,13 @@ class PredictionError(RegressionScoreVisualizer):
         is_fitted="auto",
         **kwargs
     ):
-        # Whether or not to check if the model is already fitted
-        self.is_fitted = is_fitted
 
         # Initialize the visualizer
-        super(PredictionError, self).__init__(estimator, ax=ax, **kwargs)
+        super(PredictionError, self).__init__(
+            estimator,
+            is_fitted=is_fitted,
+            ax=ax,
+            **kwargs)
 
         # Visual arguments
         self.colors = {

--- a/yellowbrick/regressor/residuals.py
+++ b/yellowbrick/regressor/residuals.py
@@ -154,11 +154,13 @@ class ResidualsPlot(RegressionScoreVisualizer):
         is_fitted="auto",
         **kwargs
     ):
-        # Whether or not to check if the model is already fitted
-        self.is_fitted = is_fitted
 
         # Initialize the visualizer base
-        super(ResidualsPlot, self).__init__(estimator, ax=ax, **kwargs)
+        super(ResidualsPlot, self).__init__(
+            estimator,
+            ax=ax,
+            is_fitted=is_fitted,
+            **kwargs)
 
         # TODO: allow more scatter plot arguments for train and test points
         # See #475 (RE: ScatterPlotMixin)


### PR DESCRIPTION
This PR fixes #1209 so that the is_fitted parameter is no longer being overwritten by the default setting.

I have made the following changes:

1. I updated the super for both ResidualsPlot and PredictionError to include is_fitted as a parameter
2. I deleted the self assignment of `is_fitted` in both visualizers
