### PR TITLE
Create tests for `is_fitted` parameter for ResidualsPlot and PredictionError

### DIFF
--- a/tests/test_regressor/test_prediction_error.py
+++ b/tests/test_regressor/test_prediction_error.py
@@ -215,6 +215,18 @@ class TestPredictionError(VisualTestCase):
         assert "alpha" in scatter_kwargs
         assert scatter_kwargs["alpha"] == 0.7
 
+    def test_is_fitted_param(self):
+        """
+        Test that the user can supply an is_fitted param and it's state is maintained
+        """
+        # Instantiate a sklearn regressor
+        model = Lasso(random_state=23, alpha=10)
+        # Instantiate a prediction error plot, provide custom alpha
+        visualizer = PredictionError(model, bestfit=False, identity=False, is_fitted=False)
+
+        # Test param gets set correctly
+        assert visualizer.is_fitted == False
+    
     @pytest.mark.xfail(
         reason="""third test fails with AssertionError: Expected fit
         to be called once. Called 0 times."""

--- a/tests/test_regressor/test_residuals.py
+++ b/tests/test_regressor/test_residuals.py
@@ -18,6 +18,7 @@ Ensure that the regressor residuals visualizations work.
 ## Imports
 ##########################################################################
 
+from random import random
 import sys
 import pytest
 import matplotlib as mpl
@@ -314,6 +315,16 @@ class TestResidualsPlot(VisualTestCase):
         assert "alpha" in scatter_kwargs
         assert scatter_kwargs["alpha"] == 0.75
 
+    def test_is_fitted_param(self):
+        """
+        Test that the user can supply an is_fitted param and it's state is maintained
+        """
+        # Instantiate a prediction error plot, provide custom is_fitted
+        visualizer = ResidualsPlot(Ridge(random_state=8893), is_fitted=False)
+
+        # Test param gets set correctly
+        assert visualizer.is_fitted == False
+    
     @pytest.mark.xfail(
         reason="""third test fails with AssertionError: Expected fit
         to be called once. Called 0 times."""

--- a/tests/test_regressor/test_residuals.py
+++ b/tests/test_regressor/test_residuals.py
@@ -18,7 +18,6 @@ Ensure that the regressor residuals visualizations work.
 ## Imports
 ##########################################################################
 
-from random import random
 import sys
 import pytest
 import matplotlib as mpl


### PR DESCRIPTION
This PR adds tests to #1221. These tests assure us that the is_fitted param's state is maintained when the visualizer is instantiated.

I have made the following changes:

1. Added test for ResidualPlots
2. Added test for PredictionError
3. Removed unnecessary import so that flake8 passed

- [x] _Is the commit message formatted correctly?_
- [ ] _Have you noted the new functionality/bugfix in the release notes of the next release?_

<!-- If you've changed any code -->

- [ ] _Included a sample plot to visually illustrate your changes?_
- [x] _Do all of your functions and methods have docstrings?_
- [x] _Have you added/updated unit tests where appropriate?_
- [ ] _Have you updated the baseline images if necessary?_
- [x] _Have you run the unit tests using `pytest`?_
- [x] _Is your code style correct (are you using PEP8, pyflakes)?_
- [ ] _Have you documented your new feature/functionality in the docs?_

<!-- If you've added to the docs -->

- [ ] _Have you built the docs using `make html`?_
