### PR TITLE
Fixes #1218 Remove try/except clauses from tests

### DIFF
--- a/tests/test_cluster/test_icdm.py
+++ b/tests/test_cluster/test_icdm.py
@@ -290,10 +290,9 @@ class TestInterclusterDistance(VisualTestCase):
 
             assert not inset_locator
 
-        try:
-            InterclusterDistance(KMeans(), legend=False)
-        except YellowbrickValueError as e:
-            self.fail(e)
+        
+        InterclusterDistance(KMeans(), legend=False)
+    
 
     @pytest.mark.xfail(
         reason="""third test fails with AssertionError: Expected fit

--- a/tests/test_cluster/test_silhouette.py
+++ b/tests/test_cluster/test_silhouette.py
@@ -53,17 +53,16 @@ class TestSilhouetteVisualizer(VisualTestCase):
             n_samples=1000, n_features=12, centers=8, shuffle=False, random_state=0
         )
 
-        try:
-            fig = plt.figure()
-            ax = fig.add_subplot()
+       
+        fig = plt.figure()
+        ax = fig.add_subplot()
 
-            visualizer = SilhouetteVisualizer(KMeans(random_state=0), ax=ax)
-            visualizer.fit(X)
-            visualizer.finalize()
+        visualizer = SilhouetteVisualizer(KMeans(random_state=0), ax=ax)
+        visualizer.fit(X)
+        visualizer.finalize()
 
-            self.assert_images_similar(visualizer, remove_legend=True)
-        except Exception as e:
-            self.fail("error during silhouette: {}".format(e))
+        self.assert_images_similar(visualizer, remove_legend=True)
+        
 
     @pytest.mark.xfail(sys.platform == "win32", reason="images not close on windows")
     def test_integrated_mini_batch_kmeans_silhouette(self):
@@ -77,17 +76,15 @@ class TestSilhouetteVisualizer(VisualTestCase):
             n_samples=1000, n_features=12, centers=8, shuffle=False, random_state=0
         )
 
-        try:
-            fig = plt.figure()
-            ax = fig.add_subplot()
+        fig = plt.figure()
+        ax = fig.add_subplot()
 
-            visualizer = SilhouetteVisualizer(MiniBatchKMeans(random_state=0), ax=ax)
-            visualizer.fit(X)
-            visualizer.finalize()
+        visualizer = SilhouetteVisualizer(MiniBatchKMeans(random_state=0), ax=ax)
+        visualizer.fit(X)
+        visualizer.finalize()
 
-            self.assert_images_similar(visualizer, remove_legend=True)
-        except Exception as e:
-            self.fail("error during silhouette: {}".format(e))
+        self.assert_images_similar(visualizer, remove_legend=True)
+        
 
     @pytest.mark.skip(reason="no negative silhouette example available yet")
     def test_negative_silhouette_score(self):
@@ -106,19 +103,17 @@ class TestSilhouetteVisualizer(VisualTestCase):
             n_samples=1000, n_features=12, centers=8, shuffle=False, random_state=0
         )
 
-        try:
-            fig = plt.figure()
-            ax = fig.add_subplot()
+        
+        fig = plt.figure()
+        ax = fig.add_subplot()
 
-            visualizer = SilhouetteVisualizer(
-                MiniBatchKMeans(random_state=0), ax=ax, colormap="gnuplot"
-            )
-            visualizer.fit(X)
-            visualizer.finalize()
+        visualizer = SilhouetteVisualizer(
+            MiniBatchKMeans(random_state=0), ax=ax, colormap="gnuplot"
+        )
+        visualizer.fit(X)
+        visualizer.finalize()
 
-            self.assert_images_similar(visualizer, remove_legend=True)
-        except Exception as e:
-            self.fail("error during silhouette: {}".format(e))
+        self.assert_images_similar(visualizer, remove_legend=True)
 
     @pytest.mark.xfail(sys.platform == "win32", reason="images not close on windows")
     def test_colors_silhouette(self):
@@ -131,22 +126,19 @@ class TestSilhouetteVisualizer(VisualTestCase):
             n_samples=1000, n_features=12, centers=8, shuffle=False, random_state=0
         )
 
-        try:
-            fig = plt.figure()
-            ax = fig.add_subplot()
+        fig = plt.figure()
+        ax = fig.add_subplot()
 
-            visualizer = SilhouetteVisualizer(
-                MiniBatchKMeans(random_state=0),
-                ax=ax,
-                colors=["red", "green", "blue", "indigo", "cyan", "lavender"],
-            )
-            visualizer.fit(X)
-            visualizer.finalize()
+        visualizer = SilhouetteVisualizer(
+            MiniBatchKMeans(random_state=0),
+            ax=ax,
+            colors=["red", "green", "blue", "indigo", "cyan", "lavender"],
+        )
+        visualizer.fit(X)
+        visualizer.finalize()
 
-            self.assert_images_similar(visualizer, remove_legend=True)
-        except Exception as e:
-            self.fail("error during silhouette: {}".format(e))
-
+        self.assert_images_similar(visualizer, remove_legend=True)
+    
     def test_colormap_as_colors_silhouette(self):
         """
         Test no exceptions for modifying the colors in a silhouette visualizer
@@ -157,23 +149,20 @@ class TestSilhouetteVisualizer(VisualTestCase):
             n_samples=1000, n_features=12, centers=8, shuffle=False, random_state=0
         )
 
-        try:
-            fig = plt.figure()
-            ax = fig.add_subplot()
+        fig = plt.figure()
+        ax = fig.add_subplot()
 
-            visualizer = SilhouetteVisualizer(
-                MiniBatchKMeans(random_state=0), ax=ax, colors="cool"
-            )
-            visualizer.fit(X)
-            visualizer.finalize()
+        visualizer = SilhouetteVisualizer(
+            MiniBatchKMeans(random_state=0), ax=ax, colors="cool"
+        )
+        visualizer.fit(X)
+        visualizer.finalize()
 
-            tol = (
-                3.2 if sys.platform == "win32" else 0.01
-            )  # Fails on AppVeyor with RMS 3.143
-            self.assert_images_similar(visualizer, remove_legend=True, tol=tol)
-        except Exception as e:
-            self.fail("error during silhouette: {}".format(e))
-
+        tol = (
+            3.2 if sys.platform == "win32" else 0.01
+        )  # Fails on AppVeyor with RMS 3.143
+        self.assert_images_similar(visualizer, remove_legend=True, tol=tol)
+    
     def test_quick_method(self):
         """
         Test the quick method producing a valid visualization

--- a/tests/test_regressor/test_residuals.py
+++ b/tests/test_regressor/test_residuals.py
@@ -173,10 +173,7 @@ class TestResidualsPlot(VisualTestCase):
 
             assert not make_axes_locatable
 
-        try:
-            ResidualsPlot(LinearRegression(), hist=False)
-        except YellowbrickValueError as e:
-            self.fail(e)
+        ResidualsPlot(LinearRegression(), hist=False)
 
     @pytest.mark.xfail(
         IS_WINDOWS_OR_CONDA,


### PR DESCRIPTION
This PR fixes #1218  which reported technical debt in which there were several try/except clauses within tests that needed to be removed.  This was first identified by @rebeccabilbro in PR #1197 

I have made the following changes:

1. Remove try/except statements from tests


- [X] _Is the commit message formatted correctly?_

- [ ] _Included a sample plot to visually illustrate your changes?_
- [ ] _Do all of your functions and methods have docstrings?_
- [X] _Have you added/updated unit tests where appropriate?_
- [ ] _Have you updated the baseline images if necessary?_
- [X] _Have you run the unit tests using `pytest`?_
- [X] _Is your code style correct (are you using PEP8, pyflakes)?_
- [ ] _Have you documented your new feature/functionality in the docs?_

<!-- If you've added to the docs -->

- [ ] _Have you built the docs using `make html`?_
