### PR TITLE
Implement black code formatting as pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,4 +152,4 @@ jobs:
 
       - name: Run Checks
         run: |
-          pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref HEAD
+          pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref HEAD --show-diff-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,3 +128,28 @@ jobs:
         uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
+
+  # Run pre-commit checks on the files changed
+  linting:
+    runs-on: ubuntu-latest
+    name: Linting
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+          pre-commit install
+
+      - name: Run Checks
+        run: |
+          pre-commit run --from-ref origin/${{ github.head_ref }} --to-ref origin/${{ github.base_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,4 +152,4 @@ jobs:
 
       - name: Run Checks
         run: |
-          pre-commit run --from-ref origin/${{ github.head_ref }} --to-ref origin/${{ github.base_ref }}
+          pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref HEAD

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+-   repo: https://github.com/psf/black
+    rev: 22.6.0
+    hooks:
+    -   id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,10 @@ repos:
     rev: 22.6.0
     hooks:
     -   id: black
+-   repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
+    hooks:
+    -   id: flake8
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,15 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
+    -   id: check-json
+    -   id: check-merge-conflict
 -   repo: https://github.com/psf/black
     rev: 22.6.0
     hooks:
     -   id: black
+-   repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+    -   id: rst-backticks
+    -   id: rst-directive-colons
+    -   id: rst-inline-touching-normal

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,18 @@ Once forked, use the following steps to get your development environment set up 
     $ pip install -r docs/requirements.txt
     ```
 
-4. Switch to the develop branch.
+4. (Optional) Set up pre-commit hooks.
+
+    When opening a PR in the Yellowbrick repository, a series of checks will be run on your contribution, some of which lint and look at the formatting of your code. These may indicate some changes that need to be made before your contribution can be reviewed. You can set up pre-commit hooks to run these checks locally upon running `git commit` to ensure your contribution will pass formatting and linting checks. To set this up, you will need to uncomment the pre-commit line in `requirements.txt` and then run the following commands:
+
+    ```
+    $ pip install -r requirements.txt
+    $ pre-commit install
+    ```
+
+    The next time you run `git commit` in the Yellowbrick repository, the checks will automatically run.
+
+5. Switch to the develop branch.
 
     The Yellowbrick repository has a `develop` branch that is the primary working branch for contributions. It is probably already the branch you're on, but you can make sure and switch to it as follows::
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Language Grade: Python](https://img.shields.io/lgtm/grade/python/g/DistrictDataLabs/yellowbrick.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/DistrictDataLabs/yellowbrick/context:python)
 [![PyPI version](https://badge.fury.io/py/yellowbrick.svg)](https://badge.fury.io/py/yellowbrick)
 [![Documentation Status](https://readthedocs.org/projects/yellowbrick/badge/?version=latest)](http://yellowbrick.readthedocs.io/en/latest/?badge=latest)
+[![Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1206239.svg)](https://doi.org/10.5281/zenodo.1206239)
 [![JOSS](http://joss.theoj.org/papers/10.21105/joss.01075/status.svg)](https://doi.org/10.21105/joss.01075)
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/DistrictDataLabs/yellowbrick/develop?filepath=examples%2Fexamples.ipynb)

--- a/docs/contributing/getting_started.rst
+++ b/docs/contributing/getting_started.rst
@@ -19,7 +19,7 @@ We believe that *contribution is collaboration* and therefore emphasize *communi
 
 Once you have a good sense of how you are going to implement the new feature (or fix the bug!), you can reach out for feedback from the maintainers by creating a `pull request <https://github.com/DistrictDataLabs/yellowbrick/pulls>`_. Ideally, any pull request should be capable of resolution within 6 weeks of being opened. This timeline helps to keep our pull request queue small and allows Yellowbrick to maintain a robust release schedule to give our users the best experience possible. However, the most important thing is to keep the dialogue going! And if you're unsure whether you can complete your idea within 6 weeks, you should still go ahead and open a PR and we will be happy to help you scope it down as needed.
 
-If we have comments or questions when we evaluate your pull request and receive no response, we will also close the PR after this period of time. Please know that this does not mean we don't value your contribution, just that things go stale. If in the future you want to pick it back up, feel free to address our original feedback and to reference the original PR in a new pull request. 
+If we have comments or questions when we evaluate your pull request and receive no response, we will also close the PR after this period of time. Please know that this does not mean we don't value your contribution, just that things go stale. If in the future you want to pick it back up, feel free to address our original feedback and to reference the original PR in a new pull request.
 
 .. note:: Please note that if we feel your solution has not been thought out in earnest, or if the PR is not aligned with our `current milestone <https://github.com/districtdatalabs/yellowbrick/milestones>`_ goals, we may reach out to ask that you close the PR so that we can prioritize reviewing the most critical feature requests and bug fixes.
 
@@ -54,7 +54,7 @@ Once forked, use the following steps to get your development environment set up 
         $ pip install -e .
 
     This will add Yellowbrick to your PYTHONPATH so that you don't need to reinstall it each time you make a change during development.
-    
+
     Note that there may be other dependencies required for development and testing; you can simply install them with ``pip``. For example to install
     the additional dependencies for building the documentation or to run the
     test suite, use the ``requirements.txt`` files in those directories::
@@ -62,14 +62,23 @@ Once forked, use the following steps to get your development environment set up 
         $ pip install -r tests/requirements.txt
         $ pip install -r docs/requirements.txt
 
-4. Switch to the develop branch.
+4. (Optional) Set up pre-commit hooks.
+
+    When opening a PR in the Yellowbrick repository, a series of checks will be run on your contribution, some of which lint and look at the formatting of your code. These may indicate some changes that need to be made before your contribution can be reviewed. You can set up pre-commit hooks to run these checks locally upon running ``git commit`` to ensure your contribution will pass formatting and linting checks. To set this up, you will need to uncomment the pre-commit line in ``requirements.txt`` and then run the following commands::
+
+        $ pip install -r requirements.txt
+        $ pre-commit install
+
+    The next time you run ``git commit`` in the Yellowbrick repository, the checks will automatically run.
+
+5. Switch to the develop branch.
 
     The Yellowbrick repository has a ``develop`` branch that is the primary working branch for contributions. It is probably already the branch you're on, but you can make sure and switch to it as follows::
 
         $ git fetch
         $ git checkout develop
 
-At this point you're ready to get started writing code. 
+At this point you're ready to get started writing code.
 
 Branching Convention
 --------------------
@@ -89,7 +98,7 @@ We also recommend setting up an ``upstream`` remote so that you can easily pull 
     upstream  https://github.com/DistrictDataLabs/yellowbrick.git (fetch)
     upstream  https://github.com/DistrictDataLabs/yellowbrick.git (push)
 
-When you're ready, request a code review for your pull request. 
+When you're ready, request a code review for your pull request.
 
 Pull Requests
 -------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,6 @@ cycler>=0.10.0
 ## Build Requirements (uncomment for deployment)
 # wheel>=0.35
 # twine>=3.3
+
+## Pre-Commit Requirements (uncomment to use pre-commit hooks)
+# pre-commit>=2.20.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ filterwarnings =
 [flake8]
 # match black maximum line length
 max-line-length = 88
+extend-ignore = E203
 per-file-ignores =
     __init__.py:F401
     test_*.py:F405,F403


### PR DESCRIPTION
<!--
# Welcome Contributor!

Thank you for contributing to Yellowbrick, please follow the instructions below to get
your PR started off on the right foot.

## First Steps

1. Are you merging from a feature branch into develop?

    _If not, please create a feature branch and change your PR to merge from that branch
    into the Yellowbrick `develop` branch._

2. Does your PR have a title?

    _Please ensure your PR has a short, informative title, e.g. "Enhances ParallelCoordinates with new andrews_curve parameter" or "Corrects bug in WhiskerPlot that causes index error"_

3. Summarize your PR (HINT: See CHECKLIST/TEMPLATE below!)
-->

This PR fixes #456 which requested a pre-commit hook for `black`.

I have made the following changes:

1. Added `.pre-commit-config.yaml` to configure pre-commit hooks.

### Setup and Examples

Since we are deciding how best to have people set up the hook, here is an example of how to do so with the YAML file included in the first commit:

```shell
pip install pre-commit
pre-commit install      # run this from the yellowbrick folder after checking out this branch
```

To start with, I have provided the following hooks:
- removal of trailing whitespace
- fix end of file
- check that the YAML for the config is valid
- check that the commit won't be adding large files
- run `black`

The pre-commit hooks run automatically once you run `git commit`. Note that you don't have to install `black` because the first time you run this, `pre-commit` will build a testing environment for the staged changes (it pulls down the version of `black` specified in the YAML for you). I installed the hook before making the commits here; below is the output of my first commit:
```
$ git add .pre-commit-config.yaml 
$ git commit -m "Add .pre-commit-config.yaml with black."
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for https://github.com/psf/black.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/psf/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
black................................................(no files to check)Skipped
[feature-pre_commit_config 622c818] Add .pre-commit-config.yaml with black.
 1 file changed, 14 insertions(+)
 create mode 100644 .pre-commit-config.yaml
```

Please note that you can bypass `pre-commit` hooks by running `git commit -m "Your commit message" --no-verify`.

You can use also use `pre-commit` on specific files even if you haven't changed them yet (i.e., you have nothing to commit yet):
```shell
pre-commit run --files yellowbrick/anscombe.py
```
<img width="560" alt="Screen Shot 2022-07-29 at 7 55 27 PM" src="https://user-images.githubusercontent.com/24376333/181861599-4ee74a40-ba63-40dd-9b8d-f50f48555ae0.png">

More information and options can be found in the [pre-commit docs](https://pre-commit.com/).


### TODOs and questions

<!--
If this is a work-in-progress (WIP), list the changes you still need to make and/or questions or the Yellowbrick team. You can also mention extensions to your work that might be added as an issue to work on after the PR.
-->

Still to do:

- [x] Add setup information to contributing docs.
- [x] Potentially update `requirements.txt` files (based on discussion with maintainers).
- [x] Add other checks mentioned in comments.
- [x] Incorporate flake8 checks.
- [x] Add black badge
- [x] Look into incorporating as a GitHub Action.

Questions for the @DistrictDataLabs/team-oz-maintainers:

- [x] After experimenting with this and reviewing #456, do you want to include the `pip install` and `pre-commit` install commands in the contributors doc only? Or do you want to put `pre-commit` in the `requirements.txt` file also (note that contributors will still need to run the `pre-commit install` command)?
- [x] If we are going to add `pre-commit` to the `requirements.txt`, which one would be appropriate &ndash; I see there are a few?
- [x] Are there any other checks you would like to include?
- [x] Do you want to include the `black` badge in the README? (You can see it on the `black` README, if you aren't sure what it looks like).

### CHECKLIST

<!--
Here's a handy checklist to go through before submitting a PR, note that you can check a checkbox in Markdown by changing `- [ ]` to `- [x]` or you can create the PR and check the box manually.
-->

- [X] _Is the commit message formatted correctly?_
- [ ] _Have you noted the new functionality/bugfix in the release notes of the next release?_

<!-- If you've changed any code -->

- [x] _Have you documented your new feature/functionality in the docs?_

<!-- If you've added to the docs -->

- [x] _Have you built the docs using `make html`?_
