### PR TITLE
Only run linting actions on PRs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,28 +128,3 @@ jobs:
         uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
-
-  # Run pre-commit checks on the files changed
-  linting:
-    runs-on: ubuntu-latest
-    name: Linting
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pre-commit
-          pre-commit install
-
-      - name: Run Checks
-        run: |
-          pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref HEAD --show-diff-on-failure

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,34 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Yellowbrick PR Linting
+
+on:
+  # Trigger on pull request always (note the trailing colon)
+  pull_request:
+
+jobs:
+  # Run pre-commit checks on the files changed
+  linting:
+    runs-on: ubuntu-latest
+    name: Linting
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+          pre-commit install
+
+      - name: Run Checks
+        run: |
+          pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref HEAD --show-diff-on-failure


### PR DESCRIPTION
<!--
# Welcome Contributor!

Thank you for contributing to Yellowbrick, please follow the instructions below to get
your PR started off on the right foot.

## First Steps

1. Are you merging from a feature branch into develop?

    _If not, please create a feature branch and change your PR to merge from that branch
    into the Yellowbrick `develop` branch._

2. Does your PR have a title?

    _Please ensure your PR has a short, informative title, e.g. "Enhances ParallelCoordinates with new andrews_curve parameter" or "Corrects bug in WhiskerPlot that causes index error"_

3. Summarize your PR (HINT: See CHECKLIST/TEMPLATE below!)
-->

Continuation of https://github.com/DistrictDataLabs/yellowbrick/pull/1269 to only run the linting job for pull requests.

I have made the following changes:

1. Removed the linting job from the main CI workflow.
2. Created a new linting workflow with just the linting job to run only for pull requests.

