### PR TITLE
feature_datasaurus produce image without color usage warning message #1299

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ cycler>=0.10.0
 # twine>=3.3
 
 ## Pre-Commit Requirements (uncomment to use pre-commit hooks)
-pre-commit>=2.20.0
+# pre-commit>=2.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ cycler>=0.10.0
 # twine>=3.3
 
 ## Pre-Commit Requirements (uncomment to use pre-commit hooks)
-# pre-commit>=2.20.0
+pre-commit>=2.20.0

--- a/yellowbrick/datasaurus.py
+++ b/yellowbrick/datasaurus.py
@@ -1218,7 +1218,7 @@ def datasaurus():
         y = arr[1]
 
         # Draw the points in the scatter plot
-        ax.scatter(x, y, c=color)
+        ax.scatter(x, y, color=color)
 
         # Set the X and Y limits
         ax.set_xlim(0, 100)


### PR DESCRIPTION
This PR fixes #1299 which reported a warning about color usage in Datasaurus

I have made the following changes:

1. Replaced the parameter 'c' with 'color' in the matplotlib scatter function to produce image without warning

Sample Code

OLD: `ax.scatter(x, y, c=color)`
NEW: `ax.scatter(x, y, color=color)`


