### PR TITLE
Call _validate_steps in test_validate_steps

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -92,7 +92,7 @@ class TestVisualPipeline(object):
                     ("bad", Thing()),
                     ("model", MockEstimator()),
                 ]
-            )
+            )._validate_steps()
 
         # validate a bad intermediate transformer on the VisualPipeline
         with pytest.raises(TypeError):
@@ -102,15 +102,17 @@ class TestVisualPipeline(object):
                     ("bad", Thing()),
                     ("model", MockEstimator()),
                 ]
-            )
+            )._validate_steps()
 
         # validate a bad final estimator on the Pipeline
         with pytest.raises(TypeError):
-            Pipeline([("real", MockTransformer()), ("bad", Thing())])
+            Pipeline([("real", MockTransformer()), ("bad", Thing())])._validate_steps()
 
         # validate a bad final estimator on the VisualPipeline
         with pytest.raises(TypeError):
-            VisualPipeline([("real", MockTransformer()), ("bad", Thing())])
+            VisualPipeline(
+                [("real", MockTransformer()), ("bad", Thing())]
+            )._validate_steps()
 
         # validate visual transformers on a Pipeline
         try:


### PR DESCRIPTION
This is a required step as `Pipeline._validate_steps` method is not called by scikit-learn during construction, but it's expected by tests. I tried running it with scikit-learn v1.2.2 and scikit-learn v1.3.0. I found that in [commit 0110921 for v1.1.0](https://github.com/scikit-learn/scikit-learn/commit/01109213520eccbb9d5a51ed2930e7763c3386c4) that validation was removed upstream from `Pipeline.__init__`.

I'm currently the maintainer of the yellowbrick's [AUR package](https://aur.archlinux.org/packages/python-yellowbrick) and I'm having some trouble to update the package to v1.5.0 because of tests. The mentioned test is one of the failing tests, I brought it here in this pull request because it was simple to fix.

I've called `black` and `pytest` for the resulting file.