### PR TITLE
Handle Sphinx context injection deprecation 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -190,6 +190,15 @@ intersphinx_mapping = {
 ##########################################################################
 ## Options for HTML output
 ##########################################################################
+
+# Define the canonical URL for a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,7 @@ cycler>=0.10.0
 umap-learn>=0.5.1
 
 # Documentation Dependencies
-Sphinx>=3.4
-sphinx-rtd-theme>=0.5.1
+Sphinx==8.0.2
+sphinx-rtd-theme==3.0.0rc1
 numpydoc>=1.1
 pandas>=1.0.4


### PR DESCRIPTION
We received notification from Read the Docs that they are deprecating Sphinx context injection at build time. This PR updates the Sphinx configuration in the `docs` per the instructions provided by RTD. I've also updated the docs sphinx requirements to ensure the fix works as expected. After making these changes locally, I ran `make html` from the `docs` folder, and the docs seemed to build correctly. I'm not sure how else to test this than just opening a PR. 