### PR TITLE
Fix deprecation warning by using packaging.version instead of distutils

### DIFF
--- a/yellowbrick/style/colors.py
+++ b/yellowbrick/style/colors.py
@@ -30,9 +30,9 @@ from yellowbrick.exceptions import YellowbrickValueError
 
 
 # Check to see if matplotlib is at least sorta up to date
-from distutils.version import LooseVersion
+from packaging.version import Version
 
-mpl_ge_150 = LooseVersion(mpl.__version__) >= "1.5.0"
+mpl_ge_150 = Version(mpl.__version__) >= Version("1.5.0")
 
 
 ##########################################################################

--- a/yellowbrick/style/rcmod.py
+++ b/yellowbrick/style/rcmod.py
@@ -26,9 +26,9 @@ import numpy as np
 import matplotlib as mpl
 
 # Check to see if we have a slightly modern version of mpl
-from distutils.version import LooseVersion
+from packaging.version import Version
 
-mpl_ge_150 = LooseVersion(mpl.__version__) >= "1.5.0"
+mpl_ge_150 = Version(mpl.__version__) >= Version("1.5.0")
 
 
 from .. import _orig_rc_params


### PR DESCRIPTION
Hi, I was getting a deprecation warning because of distutils so I changed the module used to verify the version.