### PR TITLE
[WIP] Remove deprecated Matplotlib stem() parameter - Fixes #1314

### DIFF
--- a/yellowbrick/regressor/influence.py
+++ b/yellowbrick/regressor/influence.py
@@ -155,7 +155,7 @@ class CooksDistance(Visualizer):
 
         # Compute Cook's distance
         residuals_studentized = residuals / np.sqrt(mse) / np.sqrt(1 - leverage)
-        self.distance_ = residuals_studentized ** 2 / X.shape[1]
+        self.distance_ = residuals_studentized**2 / X.shape[1]
         self.distance_ *= leverage / (1 - leverage)
 
         # Compute the p-values of Cook's Distance
@@ -180,8 +180,9 @@ class CooksDistance(Visualizer):
         """
         # Draw a stem plot with the influence for each instance
         _, _, baseline = self.ax.stem(
-            self.distance_, linefmt=self.linefmt, markerfmt=self.markerfmt,
-            use_line_collection=True
+            self.distance_,
+            linefmt=self.linefmt,
+            markerfmt=self.markerfmt,
         )
 
         # No padding on either side of the instance index


### PR DESCRIPTION
## Description
This PR fixes a TypeError that occurs when using newer versions of Matplotlib 
by removing the deprecated `use_line_collection` parameter from stem plots in 
the regressor module.

## Breaking Change ⚠️
This change requires updating Yellowbrick's minimum Matplotlib dependency to 
3.6.0 or later, as this version made LineCollection the only implementation 
for stem plots.

## TODO Before Merge
- [ ] Audit all Matplotlib API usage throughout Yellowbrick for other 3.6.0+ incompatibilities
- [ ] Update minimum Matplotlib version in setup.py and requirements.txt
- [ ] Update documentation to reflect new minimum version requirement
- [ ] Add migration notes to changelog

## Testing Done
- Verified CooksDistance visualizations work correctly with Matplotlib 3.6.0+
- Tests pass locally with updated Matplotlib version

## Related Issues
- Fixes #1314

I'll remove the WIP tag once we've completed the Matplotlib version upgrade 
across the entire package.