### PR TITLE
Fix type checking functions broken by sklearn 1.8

### DIFF
--- a/yellowbrick/utils/types.py
+++ b/yellowbrick/utils/types.py
@@ -20,7 +20,12 @@ Detection utilities for Scikit-Learn and Numpy types for flexibility
 import inspect
 import numpy as np
 
-from sklearn.base import BaseEstimator
+from sklearn.base import (
+    BaseEstimator,
+    is_classifier as _sklearn_is_classifier,
+    is_regressor as _sklearn_is_regressor,
+    is_clusterer as _sklearn_is_clusterer,
+)
 from yellowbrick.contrib.wrapper import ContribEstimator
 
 
@@ -65,8 +70,8 @@ def is_classifier(estimator):
         `sklearn.is_classifier() <https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/base.py#L518>`_
     """
 
-    # Test the _estimator_type property
-    return getattr(estimator, "_estimator_type", None) == "classifier"
+    # _estimator_type removed in sklearn 1.8 — delegate to sklearn
+    return _sklearn_is_classifier(estimator)
 
 
 # Alias for closer name to isinstance and issubclass
@@ -89,8 +94,8 @@ def is_regressor(estimator):
         `sklearn.is_regressor() <https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/base.py#L531>`_
     """
 
-    # Test the _estimator_type property
-    return getattr(estimator, "_estimator_type", None) == "regressor"
+    # _estimator_type removed in sklearn 1.8 — delegate to sklearn
+    return _sklearn_is_regressor(estimator)
 
 
 # Alias for closer name to isinstance and issubclass
@@ -108,8 +113,8 @@ def is_clusterer(estimator):
         Scikit-Learn estimator or Yellowbrick visualizer
     """
 
-    # Test the _estimator_type property
-    return getattr(estimator, "_estimator_type", None) == "clusterer"
+    # _estimator_type removed in sklearn 1.8 — delegate to sklearn
+    return _sklearn_is_clusterer(estimator)
 
 
 # Alias for closer name to isinstance and issubclass

--- a/yellowbrick/utils/types.py
+++ b/yellowbrick/utils/types.py
@@ -24,7 +24,6 @@ from sklearn.base import (
     BaseEstimator,
     is_classifier as _sklearn_is_classifier,
     is_regressor as _sklearn_is_regressor,
-    is_clusterer as _sklearn_is_clusterer,
 )
 from yellowbrick.contrib.wrapper import ContribEstimator
 
@@ -112,10 +111,7 @@ def is_clusterer(estimator):
         The object to test if it is a Scikit-Learn clusterer, especially a
         Scikit-Learn estimator or Yellowbrick visualizer
     """
-
-    # _estimator_type removed in sklearn 1.8 — delegate to sklearn
-    return _sklearn_is_clusterer(estimator)
-
+    return getattr(estimator, "_estimator_type", None) == "clusterer"
 
 # Alias for closer name to isinstance and issubclass
 isclusterer = is_clusterer


### PR DESCRIPTION
While trying to use Yellowbrick with scikit-learn 1.8, I found that 
the library completely breaks — every classifier, regressor, and 
clusterer gets rejected as the wrong type.

The root cause is that sklearn 1.8 removed the `_estimator_type` 
attribute from its mixin classes. Yellowbrick's `is_classifier()`, 
`is_regressor()`, and `is_clusterer()` in `utils/types.py` were 
checking for exactly that attribute, so they now silently return 
False for every estimator.

The fix is straightforward — instead of reimplementing this check 
ourselves, just delegate to sklearn's own `is_classifier`, 
`is_regressor`, and `is_clusterer` from `sklearn.base`. They handle 
the detection correctly regardless of sklearn version.

Tested on Python 3.14 + sklearn 1.8.0 with DecisionTreeClassifier 
and LogisticRegression.

Fixes #1316
